### PR TITLE
Split entailment in Tensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,1 @@
 dist/
-.gitignore
-ghci
-.ghci
-reprof.py
-lol.sublime-project
-lol.sublime-workspace
-makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 dist/
+.gitignore
+ghci
+.ghci
+reprof.py
+lol.sublime-project
+lol.sublime-workspace
+makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 dist/
+.ghci
+ghci
+lol.sublime-project
+lol.sublime-workspace
+makefile
+reprof.py

--- a/lol.cabal
+++ b/lol.cabal
@@ -6,12 +6,12 @@ name:                lol
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
 version:             0.0.1.0
-synopsis:            A general-purpose library for lattice cryptography.
+synopsis:            A library for lattice cryptography.
 homepage:            https://github.com/cpeikert/Lol
 Bug-Reports:         https://github.com/cpeikert/Lol/issues
 license:             GPL-2
 license-file:        LICENSE
-author:              Eric Crockett, Chris Peikert
+author:              Eric Crockett <ecrockett0@gmail.com>, Chris Peikert <cpeikert@alum.mit.edu>
 maintainer:          Eric Crockett <ecrockett0@gmail.com>
 copyright:           Eric Crockett, Chris Peikert
 category:            Crypto
@@ -25,7 +25,7 @@ extra-source-files:  README,
                      test-suite/TestTypes.hs,
                      test-suite/ZqTests.hs
 cabal-version:       >=1.10
-description:         \\Lambda \\ocirc \\lambda is a general-purpose library for ring-based lattice cryptography.
+description:         Λ ○ λ (Lol) is a general-purpose library for ring-based lattice cryptography.
 source-repository head
   type: git
   location: https://github.com/cpeikert/Lol

--- a/src/Crypto/Lol/Applications/SymmSHE.hs
+++ b/src/Crypto/Lol/Applications/SymmSHE.hs
@@ -276,7 +276,7 @@ switch hint c = rescaleLinearMSD $ untag $ knapsack <$>
 
 -- | Constraint synonym for key switching.
 type KeySwitchCtx gad t m' zp zq zq' =
-  (ToSDCtx t m' zp zq, NFData (Cyc t m' zq'),
+  (ToSDCtx t m' zp zq, 
    -- EAC: same as InnerKeySwitchCtx, but duplicated for haddock
    RescaleCyc (Cyc t) zq' zq, RescaleCyc (Cyc t) zq zq',
    Decompose gad zq', KnapsackCtx t m' (DecompOf zq') zq')
@@ -458,8 +458,7 @@ type TunnelCtx t e r s e' r' s' z zp zq zq' gad =
    Reduce z zq,                     -- Reduce on Linear
    Lift zp z,                       -- liftLin
    CElt t zp,                       -- liftLin
-   KeySwitchCtx gad t s' zp zq zq', -- keySwitch
-   NFData (Cyc t s' zq'))
+   KeySwitchCtx gad t s' zp zq zq') -- keySwitch
 
 -- | Homomorphically apply the @E@-linear function that maps the
 -- elements of the decoding basis of @R\/E@ to the corresponding

--- a/src/Crypto/Lol/Applications/SymmSHE.hs
+++ b/src/Crypto/Lol/Applications/SymmSHE.hs
@@ -91,10 +91,10 @@ genSK v = liftM (SK v) $ errorRounded v
 
 -- | Constraint synonym for encryption.
 type EncryptCtx t m m' z zp zq =
-  (Mod zp, Ring zp, Ring zq, Lift zp (ModRep zp),
+  (Mod zp, Ring zp, Ring zq, Random zq, Lift zp (ModRep zp),
    Reduce z zq, Reduce (LiftOf zp) zq,
    CElt t zq, CElt t zp, CElt t z, CElt t (LiftOf zp),
-   m `Divides` m', Random zq)
+   m `Divides` m')
 
 -- | Encrypt a plaintext under a secret key.
 encrypt :: forall t m m' z zp zq e rnd . (EncryptCtx t m m' z zp zq, MonadRandom rnd)
@@ -221,7 +221,7 @@ modSwitchPT ct = let CT MSD k l c = toMSD ct in
 ---------- Key switching ----------
 
 type LWECtx t m' z zq =
-  (ToInteger z, Reduce z zq, Ring zq, Fact m', CElt t z, CElt t zq, Random zq)
+  (ToInteger z, Reduce z zq, Ring zq, Random zq, Fact m', CElt t z, CElt t zq)
 
 -- | An LWE sample for a given secret (corresponding to a linear
 -- ciphertext encrypting 0 in MSD form)

--- a/src/Crypto/Lol/Applications/SymmSHE.hs
+++ b/src/Crypto/Lol/Applications/SymmSHE.hs
@@ -94,7 +94,7 @@ type EncryptCtx t m m' z zp zq =
   (Mod zp, Ring zp, Ring zq, Lift zp (ModRep zp),
    Reduce z zq, Reduce (LiftOf zp) zq,
    CElt t zq, CElt t zp, CElt t z, CElt t (LiftOf zp),
-   m `Divides` m', Random zq)
+   m `Divides` m')
 
 -- | Encrypt a plaintext under a secret key.
 encrypt :: forall t m m' z zp zq e rnd . (EncryptCtx t m m' z zp zq, MonadRandom rnd)
@@ -221,7 +221,7 @@ modSwitchPT ct = let CT MSD k l c = toMSD ct in
 ---------- Key switching ----------
 
 type LWECtx t m' z zq =
-  (ToInteger z, Reduce z zq, Ring zq, Fact m', CElt t z, CElt t zq, Random zq)
+  (ToInteger z, Reduce z zq, Ring zq, Fact m', CElt t z, CElt t zq)
 
 -- | An LWE sample for a given secret (corresponding to a linear
 -- ciphertext encrypting 0 in MSD form)
@@ -276,7 +276,7 @@ switch hint c = rescaleLinearMSD $ untag $ knapsack <$>
 
 -- | Constraint synonym for key switching.
 type KeySwitchCtx gad t m' zp zq zq' =
-  (ToSDCtx t m' zp zq, NFData (Cyc t m' zq'),
+  (ToSDCtx t m' zp zq,
    -- EAC: same as InnerKeySwitchCtx, but duplicated for haddock
    RescaleCyc (Cyc t) zq' zq, RescaleCyc (Cyc t) zq zq',
    Decompose gad zq', KnapsackCtx t m' (DecompOf zq') zq')
@@ -458,8 +458,7 @@ type TunnelCtx t e r s e' r' s' z zp zq zq' gad =
    Reduce z zq,                     -- Reduce on Linear
    Lift zp z,                       -- liftLin
    CElt t zp,                       -- liftLin
-   KeySwitchCtx gad t s' zp zq zq', -- keySwitch
-   NFData (Cyc t s' zq'))
+   KeySwitchCtx gad t s' zp zq zq') -- keySwitch
 
 -- | Homomorphically apply the @E@-linear function that maps the
 -- elements of the decoding basis of @R\/E@ to the corresponding

--- a/src/Crypto/Lol/Applications/SymmSHE.hs
+++ b/src/Crypto/Lol/Applications/SymmSHE.hs
@@ -276,7 +276,7 @@ switch hint c = rescaleLinearMSD $ untag $ knapsack <$>
 
 -- | Constraint synonym for key switching.
 type KeySwitchCtx gad t m' zp zq zq' =
-  (ToSDCtx t m' zp zq, 
+  (ToSDCtx t m' zp zq,
    -- EAC: same as InnerKeySwitchCtx, but duplicated for haddock
    RescaleCyc (Cyc t) zq' zq, RescaleCyc (Cyc t) zq zq',
    Decompose gad zq', KnapsackCtx t m' (DecompOf zq') zq')

--- a/src/Crypto/Lol/Applications/SymmSHE.hs
+++ b/src/Crypto/Lol/Applications/SymmSHE.hs
@@ -94,7 +94,7 @@ type EncryptCtx t m m' z zp zq =
   (Mod zp, Ring zp, Ring zq, Lift zp (ModRep zp),
    Reduce z zq, Reduce (LiftOf zp) zq,
    CElt t zq, CElt t zp, CElt t z, CElt t (LiftOf zp),
-   m `Divides` m')
+   m `Divides` m', Random zq)
 
 -- | Encrypt a plaintext under a secret key.
 encrypt :: forall t m m' z zp zq e rnd . (EncryptCtx t m m' z zp zq, MonadRandom rnd)
@@ -221,7 +221,7 @@ modSwitchPT ct = let CT MSD k l c = toMSD ct in
 ---------- Key switching ----------
 
 type LWECtx t m' z zq =
-  (ToInteger z, Reduce z zq, Ring zq, Fact m', CElt t z, CElt t zq)
+  (ToInteger z, Reduce z zq, Ring zq, Fact m', CElt t z, CElt t zq, Random zq)
 
 -- | An LWE sample for a given secret (corresponding to a linear
 -- ciphertext encrypting 0 in MSD form)
@@ -276,7 +276,7 @@ switch hint c = rescaleLinearMSD $ untag $ knapsack <$>
 
 -- | Constraint synonym for key switching.
 type KeySwitchCtx gad t m' zp zq zq' =
-  (ToSDCtx t m' zp zq,
+  (ToSDCtx t m' zp zq, NFData (Cyc t m' zq'),
    -- EAC: same as InnerKeySwitchCtx, but duplicated for haddock
    RescaleCyc (Cyc t) zq' zq, RescaleCyc (Cyc t) zq zq',
    Decompose gad zq', KnapsackCtx t m' (DecompOf zq') zq')
@@ -458,7 +458,8 @@ type TunnelCtx t e r s e' r' s' z zp zq zq' gad =
    Reduce z zq,                     -- Reduce on Linear
    Lift zp z,                       -- liftLin
    CElt t zp,                       -- liftLin
-   KeySwitchCtx gad t s' zp zq zq') -- keySwitch
+   KeySwitchCtx gad t s' zp zq zq', -- keySwitch
+   NFData (Cyc t s' zq'))
 
 -- | Homomorphically apply the @E@-linear function that maps the
 -- elements of the decoding basis of @R\/E@ to the corresponding

--- a/src/Crypto/Lol/Applications/SymmSHE.hs
+++ b/src/Crypto/Lol/Applications/SymmSHE.hs
@@ -25,7 +25,7 @@ SK, PT, CT                    -- don't export constructors!
 , embedSK, embedCT, twaceCT
 , tunnelCT
 -- * Constraint synonyms
-, AddPublicCtx, MulPublicCtx, KeySwitchCtx, KSHintCtx, ModSwitchPTCtx
+, AddPublicCtx, MulPublicCtx, InnerKeySwitchCtx, KeySwitchCtx, KSHintCtx, ModSwitchPTCtx
 , ToSDCtx, EncryptCtx, TunnelCtx, GenSKCtx, DecryptCtx
 , ErrorTermCtx
 ) where
@@ -91,7 +91,7 @@ genSK v = liftM (SK v) $ errorRounded v
 
 -- | Constraint synonym for encryption.
 type EncryptCtx t m m' z zp zq =
-  (Mod zp, Ring zp, Ring zq, Random zq, Lift zp (ModRep zp),
+  (Mod zp, Ring zp, Ring zq, Lift zp (ModRep zp),
    Reduce z zq, Reduce (LiftOf zp) zq,
    CElt t zq, CElt t zp, CElt t z, CElt t (LiftOf zp),
    m `Divides` m')
@@ -221,7 +221,7 @@ modSwitchPT ct = let CT MSD k l c = toMSD ct in
 ---------- Key switching ----------
 
 type LWECtx t m' z zq =
-  (ToInteger z, Reduce z zq, Ring zq, Random zq, Fact m', CElt t z, CElt t zq)
+  (ToInteger z, Reduce z zq, Ring zq, Fact m', CElt t z, CElt t zq)
 
 -- | An LWE sample for a given secret (corresponding to a linear
 -- ciphertext encrypting 0 in MSD form)
@@ -276,10 +276,7 @@ switch hint c = rescaleLinearMSD $ untag $ knapsack <$>
 
 -- | Constraint synonym for key switching.
 type KeySwitchCtx gad t m' zp zq zq' =
-  (ToSDCtx t m' zp zq,
-   -- EAC: same as InnerKeySwitchCtx, but duplicated for haddock
-   RescaleCyc (Cyc t) zq' zq, RescaleCyc (Cyc t) zq zq',
-   Decompose gad zq', KnapsackCtx t m' (DecompOf zq') zq')
+  (ToSDCtx t m' zp zq, InnerKeySwitchCtx gad t m' zq zq')
 
 -- | Switch a linear ciphertext under @s_in@ to a linear one under @s_out@
 keySwitchLinear :: forall gad t m' zp zq zq' z rnd m .

--- a/src/Crypto/Lol/Cyclotomic/Cyc.hs
+++ b/src/Crypto/Lol/Cyclotomic/Cyc.hs
@@ -48,11 +48,10 @@ import Test.QuickCheck
 newtype Cyc t m r = Cyc { 
   -- | Unsafe deconstructor for 'Cyc'.
   unsafeUnCyc :: UCyc t m r }
-                    deriving (Arbitrary, Random)
+                    deriving (Arbitrary, NFData, Random)
 
 -- See: https://ghc.haskell.org/trac/ghc/ticket/11008
 -- for why I have to use StandaloneDeriving here
-deriving instance NFData (UCyc t m a) => NFData (Cyc t m a)
 deriving instance Show (UCyc t m a) => Show (Cyc t m a)
 deriving instance Eq (UCyc t m a) => Eq (Cyc t m a)
 deriving instance Additive (UCyc t m a) => Additive.C (Cyc t m a)

--- a/src/Crypto/Lol/Cyclotomic/Cyc.hs
+++ b/src/Crypto/Lol/Cyclotomic/Cyc.hs
@@ -48,10 +48,11 @@ import Test.QuickCheck
 newtype Cyc t m r = Cyc { 
   -- | Unsafe deconstructor for 'Cyc'.
   unsafeUnCyc :: UCyc t m r }
-                    deriving (Arbitrary, NFData, Random)
+                    deriving (Arbitrary, Random)
 
 -- See: https://ghc.haskell.org/trac/ghc/ticket/11008
 -- for why I have to use StandaloneDeriving here
+deriving instance NFData (UCyc t m a) => NFData (Cyc t m a)
 deriving instance Show (UCyc t m a) => Show (Cyc t m a)
 deriving instance Eq (UCyc t m a) => Eq (Cyc t m a)
 deriving instance Additive (UCyc t m a) => Additive.C (Cyc t m a)

--- a/src/Crypto/Lol/Cyclotomic/Linear.hs
+++ b/src/Crypto/Lol/Cyclotomic/Linear.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE ConstraintKinds, DataKinds, FlexibleContexts,
              GeneralizedNewtypeDeriving, KindSignatures,
              MultiParamTypeClasses, NoImplicitPrelude, RoleAnnotations,
-             ScopedTypeVariables, StandaloneDeriving,
-             TypeFamilies, TypeOperators, UndecidableInstances #-}
+             ScopedTypeVariables, TypeFamilies, TypeOperators,
+             UndecidableInstances #-}
 
 -- | Functions from one cyclotomic ring to another that are linear
 -- over a common subring.
@@ -22,8 +22,7 @@ import Control.DeepSeq
 
 -- | An @E@-linear function from @R@ to @S@.
 newtype Linear t z (e::Factored) (r::Factored) (s::Factored) = D [Cyc t s z]
-
-deriving instance (NFData (Cyc t s z)) => NFData (Linear t z e r s)
+  deriving (NFData)
 
 -- TODO: have constructor for both relative Pow basis of R/E?
 

--- a/src/Crypto/Lol/Cyclotomic/Linear.hs
+++ b/src/Crypto/Lol/Cyclotomic/Linear.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE ConstraintKinds, DataKinds, FlexibleContexts,
              GeneralizedNewtypeDeriving, KindSignatures,
              MultiParamTypeClasses, NoImplicitPrelude, RoleAnnotations,
-             ScopedTypeVariables, TypeFamilies, TypeOperators,
-             UndecidableInstances #-}
+             ScopedTypeVariables, StandaloneDeriving,
+             TypeFamilies, TypeOperators, UndecidableInstances #-}
 
 -- | Functions from one cyclotomic ring to another that are linear
 -- over a common subring.
@@ -22,7 +22,8 @@ import Control.DeepSeq
 
 -- | An @E@-linear function from @R@ to @S@.
 newtype Linear t z (e::Factored) (r::Factored) (s::Factored) = D [Cyc t s z]
-  deriving (NFData)
+
+deriving instance (NFData (Cyc t s z)) => NFData (Linear t z e r s)
 
 -- TODO: have constructor for both relative Pow basis of R/E?
 

--- a/src/Crypto/Lol/Cyclotomic/Tensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor.hs
@@ -51,6 +51,7 @@ import qualified Data.Vector.Unboxed  as U
 class (TElt t Double, TElt t (Complex Double))
       => Tensor (t :: Factored -> * -> *) where
 
+  -- | Constraints needed by @t@ to hold type @r@.
   type TElt t r :: Constraint
 
   -- | Properties that hold for any index. Use with '\\'.

--- a/src/Crypto/Lol/Cyclotomic/Tensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor.hs
@@ -65,26 +65,26 @@ class (TElt t Double, TElt t (Complex Double))
   entailRandomT :: Tagged (t m r) ((Fact m, TElt t r, Random r) :- (Random (t m r)))
 
   -- | Converts a scalar to a tensor in the powerful basis
-  scalarPow :: (Fact m, TElt t r) => r -> t m r
+  scalarPow :: (Fact m, TElt t r, Additive r) => r -> t m r
 
   -- | 'l' converts from decoding-basis representation to
   -- powerful-basis representation; 'lInv' is its inverse.
-  l, lInv :: (Fact m, TElt t r) => t m r -> t m r
+  l, lInv :: (Fact m, TElt t r, Additive r) => t m r -> t m r
 
   -- | Multiply by @g@ in the powerful/decoding basis
-  mulGPow, mulGDec :: (Fact m, TElt t r) => t m r -> t m r
+  mulGPow, mulGDec :: (Fact m, TElt t r, Additive r) => t m r -> t m r
 
   -- | Divide by @g@ in the powerful/decoding basis.  The 'Maybe'
   -- output indicates that the operation may fail, which happens
   -- exactly when the input is not divisible by @g@.
-  divGPow, divGDec :: (Fact m, TElt t r) => t m r -> Maybe (t m r)
+  divGPow, divGDec :: (Fact m, TElt t r, ZeroTestable r, IntegralDomain r) => t m r -> Maybe (t m r)
 
   -- | A tuple of all the operations relating to the CRT basis, in a
   -- single 'Maybe' value for safety.  Clients should typically not
   -- use this method directly, but instead call the corresponding
   -- top-level functions: the elements of the tuple correpond to the
   -- functions 'scalarCRT', 'mulGCRT', 'divGCRT', 'crt', 'crtInv'.
-  crtFuncs :: (Fact m, TElt t r, CRTrans r) =>
+  crtFuncs :: (Fact m, TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r) =>
               Maybe (    r -> t m r, -- scalarCRT
                      t m r -> t m r, -- mulGCRT
                      t m r -> t m r, -- divGCRT
@@ -103,7 +103,7 @@ class (TElt t Double, TElt t (Complex Double))
 
   -- | The @embed@ linear transformations, for the powerful and
   -- decoding bases.
-  embedPow, embedDec :: (m `Divides` m', TElt t r)
+  embedPow, embedDec :: (m `Divides` m', TElt t r, Additive r)
                         => t m r -> t m' r
 
   -- | A tuple of all the extension-related operations involving the
@@ -111,7 +111,7 @@ class (TElt t Double, TElt t (Complex Double))
   -- method directly, but instead call the corresponding top-level
   -- functions: the elements of the tuple correpond to the functions
   -- 'twaceCRT', 'embedCRT'.
-  crtExtFuncs :: (m `Divides` m', TElt t r, CRTrans r) =>
+  crtExtFuncs :: (m `Divides` m', TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r) =>
                  Maybe (t m' r -> t m  r, -- twaceCRT
                         t m  r -> t m' r) -- embedCRT
 
@@ -121,7 +121,7 @@ class (TElt t Double, TElt t (Complex Double))
   coeffs :: (m `Divides` m', TElt t r) => t m' r -> [t m r]
 
   -- | The powerful extension basis w.r.t. the powerful basis.
-  powBasisPow :: (m `Divides` m', TElt t r) => Tagged m [t m' r]
+  powBasisPow :: (m `Divides` m', TElt t r, Ring r) => Tagged m [t m' r]
 
   -- | A list of tensors representing the mod-@p@ CRT set of the
   -- extension.
@@ -137,7 +137,7 @@ class (TElt t Double, TElt t (Complex Double))
              => (a -> mon b) -> t m a -> mon (t m b)
 
 -- | Convenience value indicating whether 'crtFuncs' exists.
-hasCRTFuncs :: forall t m r . (Tensor t, Fact m, TElt t r, CRTrans r)
+hasCRTFuncs :: forall t m r . (Tensor t, Fact m, TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r)
                => TaggedT (t m r) Maybe ()
 hasCRTFuncs = tagT $ do
   (_ :: r -> t m r,_,_,_,_) <- crtFuncs
@@ -145,11 +145,11 @@ hasCRTFuncs = tagT $ do
 
 -- | Yield a tensor for a scalar in the CRT basis.  (This function is
 -- simply an appropriate entry from 'crtFuncs'.)
-scalarCRT :: (Tensor t, Fact m, TElt t r, CRTrans r) => Maybe (r -> t m r)
+scalarCRT :: (Tensor t, Fact m, TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r) => Maybe (r -> t m r)
 scalarCRT = (\(f,_,_,_,_) -> f) <$> crtFuncs
 
 
-mulGCRT, divGCRT, crt, crtInv :: (Tensor t, Fact m, TElt t r, CRTrans r)
+mulGCRT, divGCRT, crt, crtInv :: (Tensor t, Fact m, TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r)
   => Maybe (t m r -> t m r)
 -- | Multiply by @g@ in the CRT basis. (This function is simply an
 -- appropriate entry from 'crtFuncs'.)
@@ -168,7 +168,7 @@ crtInv = (\(_,_,_,_,f) -> f) <$> crtFuncs
 -- For cyclotomic indices m | m',
 -- @Tw(x) = (mhat\/m\'hat) * Tr(g\'\/g * x)@.
 -- (This function is simply an appropriate entry from 'crtExtFuncs'.)
-twaceCRT :: forall t r m m' . (Tensor t, m `Divides` m', TElt t r, CRTrans r)
+twaceCRT :: forall t r m m' . (Tensor t, m `Divides` m', TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r)
             => Maybe (t m' r -> t m r)
 twaceCRT = proxyT hasCRTFuncs (Proxy::Proxy (t m' r)) *>
            proxyT hasCRTFuncs (Proxy::Proxy (t m  r)) *>
@@ -178,7 +178,7 @@ twaceCRT = proxyT hasCRTFuncs (Proxy::Proxy (t m' r)) *>
 -- | Embed a tensor with index @m@ in the CRT basis to a tensor with
 -- index @m'@ in the CRT basis.
 -- (This function is simply an appropriate entry from 'crtExtFuncs'.)
-embedCRT :: forall t r m m' . (Tensor t, m `Divides` m', TElt t r, CRTrans r)
+embedCRT :: forall t r m m' . (Tensor t, m `Divides` m', TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r)
             => Maybe (t m r -> t m' r)
 embedCRT = proxyT hasCRTFuncs (Proxy::Proxy (t m' r)) *>
            proxyT hasCRTFuncs (Proxy::Proxy (t m  r)) *>

--- a/src/Crypto/Lol/Cyclotomic/Tensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor.hs
@@ -58,33 +58,33 @@ class (TElt t Double, TElt t (Complex Double))
   
   -- | Properties that hold for any (legal) fully-applied tensor. Use
   -- with '\\'.
-  entailEqT :: Tagged (t m r) ((Fact m, TElt t r, Eq r) :- (Eq (t m r)))
-  entailZTT :: Tagged (t m r) ((Fact m, TElt t r, ZeroTestable r) :- (ZeroTestable (t m r)))
-  entailRingT :: Tagged (t m r) ((Fact m, TElt t r, Ring r) :- (Ring (t m r)))
-  entailNFDataT :: Tagged (t m r) ((Fact m, TElt t r, NFData r) :- (NFData (t m r)))
-  entailRandomT :: Tagged (t m r) ((Fact m, TElt t r, Random r) :- (Random (t m r)))
+  entailEqT :: Tagged (t m r) ((Eq r, Fact m, TElt t r) :- (Eq (t m r)))
+  entailZTT :: Tagged (t m r) ((ZeroTestable r, Fact m, TElt t r) :- (ZeroTestable (t m r)))
+  entailRingT :: Tagged (t m r) ((Ring r, Fact m, TElt t r) :- (Ring (t m r)))
+  entailNFDataT :: Tagged (t m r) ((NFData r, Fact m, TElt t r) :- (NFData (t m r)))
+  entailRandomT :: Tagged (t m r) ((Random r, Fact m, TElt t r) :- (Random (t m r)))
 
   -- | Converts a scalar to a tensor in the powerful basis
-  scalarPow :: (Ring r, TElt t r, Fact m) => r -> t m r
+  scalarPow :: (Ring r, Fact m, TElt t r) => r -> t m r
 
   -- | 'l' converts from decoding-basis representation to
   -- powerful-basis representation; 'lInv' is its inverse.
-  l, lInv :: (Ring r, TElt t r, Fact m) => t m r -> t m r
+  l, lInv :: (Ring r, Fact m, TElt t r) => t m r -> t m r
 
   -- | Multiply by @g@ in the powerful/decoding basis
-  mulGPow, mulGDec :: (Ring r, TElt t r, Fact m) => t m r -> t m r
+  mulGPow, mulGDec :: (Ring r, Fact m, TElt t r) => t m r -> t m r
 
   -- | Divide by @g@ in the powerful/decoding basis.  The 'Maybe'
   -- output indicates that the operation may fail, which happens
   -- exactly when the input is not divisible by @g@.
-  divGPow, divGDec :: (ZeroTestable r, IntegralDomain r, TElt t r, Fact m) => t m r -> Maybe (t m r)
+  divGPow, divGDec :: (ZeroTestable r, IntegralDomain r, Fact m, TElt t r) => t m r -> Maybe (t m r)
 
   -- | A tuple of all the operations relating to the CRT basis, in a
   -- single 'Maybe' value for safety.  Clients should typically not
   -- use this method directly, but instead call the corresponding
   -- top-level functions: the elements of the tuple correpond to the
   -- functions 'scalarCRT', 'mulGCRT', 'divGCRT', 'crt', 'crtInv'.
-  crtFuncs :: (ZeroTestable r, IntegralDomain r, CRTrans r, TElt t r, Fact m) =>
+  crtFuncs :: (ZeroTestable r, IntegralDomain r, CRTrans r, Fact m, TElt t r) =>
               Maybe (    r -> t m r, -- scalarCRT
                      t m r -> t m r, -- mulGCRT
                      t m r -> t m r, -- divGCRT
@@ -93,8 +93,8 @@ class (TElt t Double, TElt t (Complex Double))
 
   -- | Sample from the "skewed" Gaussian error distribution @t*D@
   -- in the decoding basis, where @D@ has scaled variance @v@.
-  tGaussianDec :: (Fact m, OrdFloat q, Random q, TElt t q,
-                   ToRational v, MonadRandom rnd)
+  tGaussianDec :: (OrdFloat q, Random q, TElt t q,
+                   ToRational v, Fact m, MonadRandom rnd)
                   => v -> rnd (t m q)
 
   -- | The @twace@ linear transformation, which is the same in both the
@@ -103,7 +103,7 @@ class (TElt t Double, TElt t (Complex Double))
 
   -- | The @embed@ linear transformations, for the powerful and
   -- decoding bases.
-  embedPow, embedDec :: (Ring r, TElt t r, m `Divides` m')
+  embedPow, embedDec :: (Ring r, m `Divides` m', TElt t r)
                         => t m r -> t m' r
 
   -- | A tuple of all the extension-related operations involving the
@@ -111,7 +111,7 @@ class (TElt t Double, TElt t (Complex Double))
   -- method directly, but instead call the corresponding top-level
   -- functions: the elements of the tuple correpond to the functions
   -- 'twaceCRT', 'embedCRT'.
-  crtExtFuncs :: (ZeroTestable r, IntegralDomain r, CRTrans r, TElt t r, m `Divides` m') =>
+  crtExtFuncs :: (ZeroTestable r, IntegralDomain r, CRTrans r, m `Divides` m', TElt t r) =>
                  Maybe (t m' r -> t m  r, -- twaceCRT
                         t m  r -> t m' r) -- embedCRT
 
@@ -137,7 +137,7 @@ class (TElt t Double, TElt t (Complex Double))
              => (a -> mon b) -> t m a -> mon (t m b)
 
 -- | Convenience value indicating whether 'crtFuncs' exists.
-hasCRTFuncs :: forall t m r . (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, Fact m)
+hasCRTFuncs :: forall t m r . (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, Fact m, TElt t r)
                => TaggedT (t m r) Maybe ()
 hasCRTFuncs = tagT $ do
   (_ :: r -> t m r,_,_,_,_) <- crtFuncs
@@ -145,11 +145,11 @@ hasCRTFuncs = tagT $ do
 
 -- | Yield a tensor for a scalar in the CRT basis.  (This function is
 -- simply an appropriate entry from 'crtFuncs'.)
-scalarCRT :: (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, Fact m) => Maybe (r -> t m r)
+scalarCRT :: (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, Fact m, TElt t r) => Maybe (r -> t m r)
 scalarCRT = (\(f,_,_,_,_) -> f) <$> crtFuncs
 
 
-mulGCRT, divGCRT, crt, crtInv :: (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, Fact m)
+mulGCRT, divGCRT, crt, crtInv :: (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, Fact m, TElt t r)
   => Maybe (t m r -> t m r)
 -- | Multiply by @g@ in the CRT basis. (This function is simply an
 -- appropriate entry from 'crtFuncs'.)
@@ -168,7 +168,7 @@ crtInv = (\(_,_,_,_,f) -> f) <$> crtFuncs
 -- For cyclotomic indices m | m',
 -- @Tw(x) = (mhat\/m\'hat) * Tr(g\'\/g * x)@.
 -- (This function is simply an appropriate entry from 'crtExtFuncs'.)
-twaceCRT :: forall t r m m' . (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, m `Divides` m')
+twaceCRT :: forall t r m m' . (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, m `Divides` m', TElt t r)
             => Maybe (t m' r -> t m r)
 twaceCRT = proxyT hasCRTFuncs (Proxy::Proxy (t m' r)) *>
            proxyT hasCRTFuncs (Proxy::Proxy (t m  r)) *>
@@ -178,7 +178,7 @@ twaceCRT = proxyT hasCRTFuncs (Proxy::Proxy (t m' r)) *>
 -- | Embed a tensor with index @m@ in the CRT basis to a tensor with
 -- index @m'@ in the CRT basis.
 -- (This function is simply an appropriate entry from 'crtExtFuncs'.)
-embedCRT :: forall t r m m' . (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, m `Divides` m')
+embedCRT :: forall t r m m' . (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, m `Divides` m', TElt t r)
             => Maybe (t m r -> t m' r)
 embedCRT = proxyT hasCRTFuncs (Proxy::Proxy (t m' r)) *>
            proxyT hasCRTFuncs (Proxy::Proxy (t m  r)) *>

--- a/src/Crypto/Lol/Cyclotomic/Tensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor.hs
@@ -65,26 +65,26 @@ class (TElt t Double, TElt t (Complex Double))
   entailRandomT :: Tagged (t m r) ((Fact m, TElt t r, Random r) :- (Random (t m r)))
 
   -- | Converts a scalar to a tensor in the powerful basis
-  scalarPow :: (Fact m, TElt t r, Additive r) => r -> t m r
+  scalarPow :: (Ring r, TElt t r, Fact m) => r -> t m r
 
   -- | 'l' converts from decoding-basis representation to
   -- powerful-basis representation; 'lInv' is its inverse.
-  l, lInv :: (Fact m, TElt t r, Additive r) => t m r -> t m r
+  l, lInv :: (Ring r, TElt t r, Fact m) => t m r -> t m r
 
   -- | Multiply by @g@ in the powerful/decoding basis
-  mulGPow, mulGDec :: (Fact m, TElt t r, Additive r) => t m r -> t m r
+  mulGPow, mulGDec :: (Ring r, TElt t r, Fact m) => t m r -> t m r
 
   -- | Divide by @g@ in the powerful/decoding basis.  The 'Maybe'
   -- output indicates that the operation may fail, which happens
   -- exactly when the input is not divisible by @g@.
-  divGPow, divGDec :: (Fact m, TElt t r, ZeroTestable r, IntegralDomain r) => t m r -> Maybe (t m r)
+  divGPow, divGDec :: (ZeroTestable r, IntegralDomain r, TElt t r, Fact m) => t m r -> Maybe (t m r)
 
   -- | A tuple of all the operations relating to the CRT basis, in a
   -- single 'Maybe' value for safety.  Clients should typically not
   -- use this method directly, but instead call the corresponding
   -- top-level functions: the elements of the tuple correpond to the
   -- functions 'scalarCRT', 'mulGCRT', 'divGCRT', 'crt', 'crtInv'.
-  crtFuncs :: (Fact m, TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r) =>
+  crtFuncs :: (ZeroTestable r, IntegralDomain r, CRTrans r, TElt t r, Fact m) =>
               Maybe (    r -> t m r, -- scalarCRT
                      t m r -> t m r, -- mulGCRT
                      t m r -> t m r, -- divGCRT
@@ -103,7 +103,7 @@ class (TElt t Double, TElt t (Complex Double))
 
   -- | The @embed@ linear transformations, for the powerful and
   -- decoding bases.
-  embedPow, embedDec :: (m `Divides` m', TElt t r, Additive r)
+  embedPow, embedDec :: (Ring r, TElt t r, m `Divides` m')
                         => t m r -> t m' r
 
   -- | A tuple of all the extension-related operations involving the
@@ -111,7 +111,7 @@ class (TElt t Double, TElt t (Complex Double))
   -- method directly, but instead call the corresponding top-level
   -- functions: the elements of the tuple correpond to the functions
   -- 'twaceCRT', 'embedCRT'.
-  crtExtFuncs :: (m `Divides` m', TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r) =>
+  crtExtFuncs :: (ZeroTestable r, IntegralDomain r, CRTrans r, TElt t r, m `Divides` m') =>
                  Maybe (t m' r -> t m  r, -- twaceCRT
                         t m  r -> t m' r) -- embedCRT
 
@@ -121,7 +121,7 @@ class (TElt t Double, TElt t (Complex Double))
   coeffs :: (m `Divides` m', TElt t r) => t m' r -> [t m r]
 
   -- | The powerful extension basis w.r.t. the powerful basis.
-  powBasisPow :: (m `Divides` m', TElt t r, Ring r) => Tagged m [t m' r]
+  powBasisPow :: (Ring r, TElt t r, m `Divides` m') => Tagged m [t m' r]
 
   -- | A list of tensors representing the mod-@p@ CRT set of the
   -- extension.
@@ -137,7 +137,7 @@ class (TElt t Double, TElt t (Complex Double))
              => (a -> mon b) -> t m a -> mon (t m b)
 
 -- | Convenience value indicating whether 'crtFuncs' exists.
-hasCRTFuncs :: forall t m r . (Tensor t, Fact m, TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r)
+hasCRTFuncs :: forall t m r . (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, Fact m)
                => TaggedT (t m r) Maybe ()
 hasCRTFuncs = tagT $ do
   (_ :: r -> t m r,_,_,_,_) <- crtFuncs
@@ -145,11 +145,11 @@ hasCRTFuncs = tagT $ do
 
 -- | Yield a tensor for a scalar in the CRT basis.  (This function is
 -- simply an appropriate entry from 'crtFuncs'.)
-scalarCRT :: (Tensor t, Fact m, TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r) => Maybe (r -> t m r)
+scalarCRT :: (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, Fact m) => Maybe (r -> t m r)
 scalarCRT = (\(f,_,_,_,_) -> f) <$> crtFuncs
 
 
-mulGCRT, divGCRT, crt, crtInv :: (Tensor t, Fact m, TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r)
+mulGCRT, divGCRT, crt, crtInv :: (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, Fact m)
   => Maybe (t m r -> t m r)
 -- | Multiply by @g@ in the CRT basis. (This function is simply an
 -- appropriate entry from 'crtFuncs'.)
@@ -168,7 +168,7 @@ crtInv = (\(_,_,_,_,f) -> f) <$> crtFuncs
 -- For cyclotomic indices m | m',
 -- @Tw(x) = (mhat\/m\'hat) * Tr(g\'\/g * x)@.
 -- (This function is simply an appropriate entry from 'crtExtFuncs'.)
-twaceCRT :: forall t r m m' . (Tensor t, m `Divides` m', TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r)
+twaceCRT :: forall t r m m' . (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, m `Divides` m')
             => Maybe (t m' r -> t m r)
 twaceCRT = proxyT hasCRTFuncs (Proxy::Proxy (t m' r)) *>
            proxyT hasCRTFuncs (Proxy::Proxy (t m  r)) *>
@@ -178,7 +178,7 @@ twaceCRT = proxyT hasCRTFuncs (Proxy::Proxy (t m' r)) *>
 -- | Embed a tensor with index @m@ in the CRT basis to a tensor with
 -- index @m'@ in the CRT basis.
 -- (This function is simply an appropriate entry from 'crtExtFuncs'.)
-embedCRT :: forall t r m m' . (Tensor t, m `Divides` m', TElt t r, CRTrans r, ZeroTestable r, IntegralDomain r)
+embedCRT :: forall t r m m' . (ZeroTestable r, IntegralDomain r, CRTrans r, Tensor t, TElt t r, m `Divides` m')
             => Maybe (t m r -> t m' r)
 embedCRT = proxyT hasCRTFuncs (Proxy::Proxy (t m' r)) *>
            proxyT hasCRTFuncs (Proxy::Proxy (t m  r)) *>

--- a/src/Crypto/Lol/Cyclotomic/Tensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor.hs
@@ -54,15 +54,15 @@ class (TElt t Double, TElt t (Complex Double))
   type TElt t r :: Constraint
 
   -- | Properties that hold for any index. Use with '\\'.
-  entailIndexT :: Tagged (t m r)
-                  (Fact m :- (Applicative (t m), Traversable (t m)))
+  entailIndexT :: Tagged (t m r) (Fact m :- (Applicative (t m), Traversable (t m)))
   
   -- | Properties that hold for any (legal) fully-applied tensor. Use
   -- with '\\'.
-  entailFullT :: Tagged (t m r)
-                 ((Fact m, TElt t r) :- 
-                  (Eq (t m r), ZeroTestable (t m r), Ring (t m r), 
-                   NFData (t m r), Random (t m r)))
+  entailEqT :: Tagged (t m r) ((Fact m, TElt t r, Eq r) :- (Eq (t m r)))
+  entailZTT :: Tagged (t m r) ((Fact m, TElt t r, ZeroTestable r) :- (ZeroTestable (t m r)))
+  entailRingT :: Tagged (t m r) ((Fact m, TElt t r, Ring r) :- (Ring (t m r)))
+  entailNFDataT :: Tagged (t m r) ((Fact m, TElt t r, NFData r) :- (NFData (t m r)))
+  entailRandomT :: Tagged (t m r) ((Fact m, TElt t r, Random r) :- (Random (t m r)))
 
   -- | Converts a scalar to a tensor in the powerful basis
   scalarPow :: (Fact m, TElt t r) => r -> t m r

--- a/src/Crypto/Lol/Cyclotomic/Tensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor.hs
@@ -54,15 +54,15 @@ class (TElt t Double, TElt t (Complex Double))
   type TElt t r :: Constraint
 
   -- | Properties that hold for any index. Use with '\\'.
-  entailIndexT :: Tagged (t m r) (Fact m :- (Applicative (t m), Traversable (t m)))
+  entailIndexT :: Tagged (t m r)
+                  (Fact m :- (Applicative (t m), Traversable (t m)))
   
   -- | Properties that hold for any (legal) fully-applied tensor. Use
   -- with '\\'.
-  entailEqT :: Tagged (t m r) ((Fact m, TElt t r, Eq r) :- (Eq (t m r)))
-  entailZTT :: Tagged (t m r) ((Fact m, TElt t r, ZeroTestable r) :- (ZeroTestable (t m r)))
-  entailRingT :: Tagged (t m r) ((Fact m, TElt t r, Ring r) :- (Ring (t m r)))
-  entailNFDataT :: Tagged (t m r) ((Fact m, TElt t r, NFData r) :- (NFData (t m r)))
-  entailRandomT :: Tagged (t m r) ((Fact m, TElt t r, Random r) :- (Random (t m r)))
+  entailFullT :: Tagged (t m r)
+                 ((Fact m, TElt t r) :- 
+                  (Eq (t m r), ZeroTestable (t m r), Ring (t m r), 
+                   NFData (t m r), Random (t m r)))
 
   -- | Converts a scalar to a tensor in the powerful basis
   scalarPow :: (Fact m, TElt t r) => r -> t m r

--- a/src/Crypto/Lol/Cyclotomic/Tensor/CTensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor/CTensor.hs
@@ -164,12 +164,15 @@ instance Fact m => Traversable (CT m) where
 
 instance Tensor CT where
 
-  type TElt CT r = (IntegralDomain r, ZeroTestable r, 
-                    Eq r, Random r, NFData r,
-                    Storable r, CRNS r)
+  type TElt CT r = (Storable r, CRNS r)
 
   entailIndexT = tag $ Sub Dict
-  entailFullT = tag $ Sub Dict
+  entailEqT = tag $ Sub Dict
+  entailZTT = tag $ Sub Dict
+  entailRingT = tag $ Sub Dict
+  entailNFDataT = tag $ Sub Dict
+  entailRandomT = tag $ Sub Dict
+
 
   scalarPow = CT . scalarPow' -- Vector code
 

--- a/src/Crypto/Lol/Cyclotomic/Tensor/CTensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor/CTensor.hs
@@ -164,15 +164,12 @@ instance Fact m => Traversable (CT m) where
 
 instance Tensor CT where
 
-  type TElt CT r = (Storable r, CRNS r)
+  type TElt CT r = (IntegralDomain r, ZeroTestable r, 
+                    Eq r, Random r, NFData r,
+                    Storable r, CRNS r)
 
   entailIndexT = tag $ Sub Dict
-  entailEqT = tag $ Sub Dict
-  entailZTT = tag $ Sub Dict
-  entailRingT = tag $ Sub Dict
-  entailNFDataT = tag $ Sub Dict
-  entailRandomT = tag $ Sub Dict
-
+  entailFullT = tag $ Sub Dict
 
   scalarPow = CT . scalarPow' -- Vector code
 

--- a/src/Crypto/Lol/Cyclotomic/Tensor/RepaTensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor/RepaTensor.hs
@@ -75,12 +75,14 @@ wrapM f (ZV v) = liftM RT $ f $ zvToArr v
 
 instance Tensor RT where
 
-  type TElt RT r = (IntegralDomain r, ZeroTestable r,
-                    Eq r, Random r, NFData r,
-                    Unbox r, Elt r)
+  type TElt RT r = (Unbox r, Elt r)
 
   entailIndexT  = tag $ Sub Dict
-  entailFullT   = tag $ Sub Dict
+  entailEqT = tag $ Sub Dict
+  entailZTT = tag $ Sub Dict
+  entailRingT = tag $ Sub Dict
+  entailNFDataT = tag $ Sub Dict
+  entailRandomT = tag $ Sub Dict
 
   scalarPow = RT . scalarPow'
 

--- a/src/Crypto/Lol/Cyclotomic/Tensor/RepaTensor.hs
+++ b/src/Crypto/Lol/Cyclotomic/Tensor/RepaTensor.hs
@@ -75,14 +75,12 @@ wrapM f (ZV v) = liftM RT $ f $ zvToArr v
 
 instance Tensor RT where
 
-  type TElt RT r = (Unbox r, Elt r)
+  type TElt RT r = (IntegralDomain r, ZeroTestable r,
+                    Eq r, Random r, NFData r,
+                    Unbox r, Elt r)
 
   entailIndexT  = tag $ Sub Dict
-  entailEqT = tag $ Sub Dict
-  entailZTT = tag $ Sub Dict
-  entailRingT = tag $ Sub Dict
-  entailNFDataT = tag $ Sub Dict
-  entailRandomT = tag $ Sub Dict
+  entailFullT   = tag $ Sub Dict
 
   scalarPow = RT . scalarPow'
 

--- a/src/Crypto/Lol/Cyclotomic/UCyc.hs
+++ b/src/Crypto/Lol/Cyclotomic/UCyc.hs
@@ -96,14 +96,14 @@ data UCyc t (m :: Factored) r where
 
 -- | Shorthand for frequently reused constraints that are needed for
 --  change of basis.
-type UCCtx t r = (Tensor t, Foo t r, Foo t (CRTExt r), CRTEmbed r)
+type UCCtx t r = (Tensor t, RElt t r, RElt t (CRTExt r), CRTEmbed r)
 
 -- | Collection of constraints need to work on most functions over a particular base ring @r@.
 type RElt t r = (TElt t r, CRTrans r, IntegralDomain r, ZeroTestable r, NFData r)
 
 -- | Shorthand for frequently reused constraints that are needed for
 -- most functions involving 'UCyc' and 'Crypto.Lol.Cyclotomic.Cyc.Cyc'.
-type CElt t r = (Tensor t, Foo t r, Foo t (CRTExt r), CRTEmbed r, Eq r)
+type CElt t r = (Tensor t, RElt t r, RElt t (CRTExt r), CRTEmbed r, Eq r)
 
 -- | Same as 'Crypto.Lol.Cyclotomic.Cyc.scalarCyc', but for 'UCyc'.
 scalarCyc :: (Fact m, CElt t a) => a -> UCyc t m a
@@ -644,7 +644,7 @@ instance (Arbitrary (t m r)) => Arbitrary (UCyc t m r) where
   arbitrary = liftM Pow arbitrary
   shrink = shrinkNothing
 
-instance (Tensor t, Fact m, NFData r, TElt t r, TElt t (CRTExt r), NFData (CRTExt r))
+instance (Tensor t, Fact m, TElt t r, TElt t (CRTExt r), NFData r, NFData (CRTExt r))
          => NFData (UCyc t m r) where
   rnf (Pow x)    = rnf x \\ witness entailNFDataT x
   rnf (Dec x)    = rnf x \\ witness entailNFDataT x

--- a/src/Crypto/Lol/Cyclotomic/UCyc.hs
+++ b/src/Crypto/Lol/Cyclotomic/UCyc.hs
@@ -96,15 +96,15 @@ data UCyc t (m :: Factored) r where
 
 -- | Shorthand for frequently reused constraints that are needed for
 --  change of basis.
-type UCCtx t r = (Tensor t, CRTrans r, CRTrans (CRTExt r), CRTEmbed r,
-                  ZeroTestable r, TElt t r, TElt t (CRTExt r))
+type UCCtx t r = (Tensor t, CRTrans r, CRTrans (CRTExt r), CRTEmbed r, IntegralDomain r, IntegralDomain (CRTExt r),
+                  ZeroTestable r, ZeroTestable (CRTExt r), TElt t r, TElt t (CRTExt r))
 
 -- | Shorthand for frequently reused constraints that are needed for
 -- most functions involving 'UCyc' and 'Crypto.Lol.Cyclotomic.Cyc.Cyc'.
 
 -- EAC: duplicated UCCtx for haddock
-type CElt t r = (Tensor t, CRTrans r, CRTrans (CRTExt r), CRTEmbed r,
-                 ZeroTestable r, TElt t r, TElt t (CRTExt r), Eq r, NFData r)
+type CElt t r = (Tensor t, CRTrans r, CRTrans (CRTExt r), CRTEmbed r, IntegralDomain r, IntegralDomain (CRTExt r),
+                 ZeroTestable r, ZeroTestable (CRTExt r), TElt t r, TElt t (CRTExt r), Eq r, NFData r)
 
 -- | Same as 'Crypto.Lol.Cyclotomic.Cyc.scalarCyc', but for 'UCyc'.
 scalarCyc :: (Fact m, CElt t a) => a -> UCyc t m a
@@ -620,7 +620,7 @@ instance (Tensor t, Fact m) => Traversable (UCyc t m) where
 
 ---------- Utility instances ----------
 
-instance (Tensor t, Fact m, TElt t r, CRTrans r, Random r) => Random (UCyc t m r) where
+instance (Tensor t, Fact m, TElt t r, CRTrans r, Random r, ZeroTestable r, IntegralDomain r) => Random (UCyc t m r) where
 
   -- create in CRTr basis if legal, otherwise in powerful
   random = let cons = fromMaybe Pow

--- a/src/Crypto/Lol/Cyclotomic/UCyc.hs
+++ b/src/Crypto/Lol/Cyclotomic/UCyc.hs
@@ -28,7 +28,7 @@
 module Crypto.Lol.Cyclotomic.UCyc
 (
 -- * Data type
-  UCyc, CElt
+  UCyc, CElt, RElt
 -- * Basic operations
 , mulG, divG
 , scalarCyc, liftCyc
@@ -96,15 +96,14 @@ data UCyc t (m :: Factored) r where
 
 -- | Shorthand for frequently reused constraints that are needed for
 --  change of basis.
-type UCCtx t r = (Tensor t, CRTrans r, CRTrans (CRTExt r), CRTEmbed r, IntegralDomain r, IntegralDomain (CRTExt r),
-                  ZeroTestable r, ZeroTestable (CRTExt r), TElt t r, TElt t (CRTExt r))
+type UCCtx t r = (Tensor t, Foo t r, Foo t (CRTExt r), CRTEmbed r)
+
+-- | Collection of constraints need to work on most functions over a particular base ring @r@.
+type RElt t r = (TElt t r, CRTrans r, IntegralDomain r, ZeroTestable r, NFData r)
 
 -- | Shorthand for frequently reused constraints that are needed for
 -- most functions involving 'UCyc' and 'Crypto.Lol.Cyclotomic.Cyc.Cyc'.
-
--- EAC: duplicated UCCtx for haddock
-type CElt t r = (Tensor t, CRTrans r, CRTrans (CRTExt r), CRTEmbed r, IntegralDomain r, IntegralDomain (CRTExt r),
-                 ZeroTestable r, ZeroTestable (CRTExt r), TElt t r, TElt t (CRTExt r), Eq r, NFData r)
+type CElt t r = (Tensor t, Foo t r, Foo t (CRTExt r), CRTEmbed r, Eq r)
 
 -- | Same as 'Crypto.Lol.Cyclotomic.Cyc.scalarCyc', but for 'UCyc'.
 scalarCyc :: (Fact m, CElt t a) => a -> UCyc t m a

--- a/src/Crypto/Lol/Cyclotomic/UCyc.hs
+++ b/src/Crypto/Lol/Cyclotomic/UCyc.hs
@@ -103,7 +103,7 @@ type RElt t r = (TElt t r, CRTrans r, IntegralDomain r, ZeroTestable r, NFData r
 
 -- | Shorthand for frequently reused constraints that are needed for
 -- most functions involving 'UCyc' and 'Crypto.Lol.Cyclotomic.Cyc.Cyc'.
-type CElt t r = (Tensor t, RElt t r, RElt t (CRTExt r), CRTEmbed r, Eq r)
+type CElt t r = (Tensor t, RElt t r, RElt t (CRTExt r), CRTEmbed r, Eq r, Random r)
 
 -- | Same as 'Crypto.Lol.Cyclotomic.Cyc.scalarCyc', but for 'UCyc'.
 scalarCyc :: (Fact m, CElt t a) => a -> UCyc t m a

--- a/src/Crypto/Lol/Cyclotomic/UCyc.hs
+++ b/src/Crypto/Lol/Cyclotomic/UCyc.hs
@@ -114,9 +114,9 @@ scalarCyc = Scalar
 instance (UCCtx t r, Fact m, Eq r) => Eq (UCyc t m r) where
   -- handle same bases when fidelity allows (i.e., *not* CRTe basis)
   (Scalar v1) == (Scalar v2) = v1 == v2
-  (Pow v1) == (Pow v2) = v1 == v2 \\ witness entailFullT v1
-  (Dec v1) == (Dec v2) = v1 == v2 \\ witness entailFullT v1
-  (CRTr v1) == (CRTr v2) = v1 == v2 \\ witness entailFullT v1
+  (Pow v1) == (Pow v2) = v1 == v2 \\ witness entailEqT v1
+  (Dec v1) == (Dec v2) = v1 == v2 \\ witness entailEqT v1
+  (CRTr v1) == (CRTr v2) = v1 == v2 \\ witness entailEqT v1
 
   (Sub (c1 :: UCyc t l1 r)) == (Sub (c2 :: UCyc t l2 r)) =
     (embed' c1 :: UCyc t (FLCM l1 l2) r) == embed' c2
@@ -131,9 +131,9 @@ instance (UCCtx t r, Fact m, Eq r) => Eq (UCyc t m r) where
 -- ZeroTestable instance
 instance (UCCtx t r, Fact m) => ZeroTestable.C (UCyc t m r) where
   isZero (Scalar v) = isZero v
-  isZero (Pow v) = isZero v \\ witness entailFullT v
-  isZero (Dec v) = isZero v \\ witness entailFullT v
-  isZero (CRTr v) = isZero v \\ witness entailFullT v
+  isZero (Pow v) = isZero v \\ witness entailZTT v
+  isZero (Dec v) = isZero v \\ witness entailZTT v
+  isZero (CRTr v) = isZero v \\ witness entailZTT v
   isZero x@(CRTe _) = isZero $ toPow' x
   isZero (Sub c) = isZero c
 
@@ -148,11 +148,11 @@ instance (UCCtx t r, Fact m) => Additive.C (UCyc t m r) where
 
   -- SAME CONSTRUCTORS
   (Scalar c1) + (Scalar c2) = Scalar (c1+c2)
-  (Pow v1) + (Pow v2) = Pow $ v1 + v2 \\ witness entailFullT v1
-  (Dec v1) + (Dec v2) = Dec $ v1 + v2 \\ witness entailFullT v1
-  (CRTr v1) + (CRTr v2) = CRTr $ v1 + v2 \\ witness entailFullT v1
+  (Pow v1) + (Pow v2) = Pow $ v1 + v2 \\ witness entailRingT v1
+  (Dec v1) + (Dec v2) = Dec $ v1 + v2 \\ witness entailRingT v1
+  (CRTr v1) + (CRTr v2) = CRTr $ v1 + v2 \\ witness entailRingT v1
   -- CJP: is this OK for precision?
-  (CRTe v1) + (CRTe v2) = CRTe $ v1 + v2 \\ witness entailFullT v1
+  (CRTe v1) + (CRTe v2) = CRTe $ v1 + v2 \\ witness entailRingT v1
   -- Sub plus Sub: work in compositum
   (Sub (c1 :: UCyc t m1 r)) + (Sub (c2 :: UCyc t m2 r)) =
     (Sub $ (embed' c1 :: UCyc t (FLCM m1 m2) r) + embed' c2)
@@ -205,8 +205,8 @@ instance (UCCtx t r, Fact m) => Ring.C (UCyc t m r) where
   _ * v2@(Scalar c2) | isZero c2 = v2
 
   -- BOTH IN A CRT BASIS
-  (CRTr v1) * (CRTr v2) = CRTr $ v1 * v2 \\ witness entailFullT v1
-  (CRTe v1) * (CRTe v2) = toPow' $ CRTe $ v1 * v2 \\ witness entailFullT v1
+  (CRTr v1) * (CRTr v2) = CRTr $ v1 * v2 \\ witness entailRingT v1
+  (CRTe v1) * (CRTe v2) = toPow' $ CRTe $ v1 * v2 \\ witness entailRingT v1
 
   -- AT LEAST ONE SCALAR
   (Scalar c1) * (Scalar c2) = Scalar $ c1 * c2
@@ -620,13 +620,13 @@ instance (Tensor t, Fact m) => Traversable (UCyc t m) where
 
 ---------- Utility instances ----------
 
-instance (Tensor t, Fact m, TElt t r, CRTrans r) => Random (UCyc t m r) where
+instance (Tensor t, Fact m, TElt t r, CRTrans r, Random r) => Random (UCyc t m r) where
 
   -- create in CRTr basis if legal, otherwise in powerful
   random = let cons = fromMaybe Pow
                       (proxyT hasCRTFuncs (Proxy::Proxy (t m r)) >> Just CRTr)
            in \g -> let (v,g') = random g
-                                 \\ proxy entailFullT (Proxy::Proxy (t m r))
+                                 \\ proxy entailRandomT (Proxy::Proxy (t m r))
                     in (cons v, g')
 
   randomR _ = error "randomR non-sensical for cyclotomic rings"
@@ -645,11 +645,11 @@ instance (Arbitrary (t m r)) => Arbitrary (UCyc t m r) where
   arbitrary = liftM Pow arbitrary
   shrink = shrinkNothing
 
-instance (Tensor t, Fact m, NFData r, TElt t r, TElt t (CRTExt r))
+instance (Tensor t, Fact m, NFData r, TElt t r, TElt t (CRTExt r), NFData (CRTExt r))
          => NFData (UCyc t m r) where
-  rnf (Pow x)    = rnf x \\ witness entailFullT x
-  rnf (Dec x)    = rnf x \\ witness entailFullT x
-  rnf (CRTr x)   = rnf x \\ witness entailFullT x
-  rnf (CRTe x)   = rnf x \\ witness entailFullT x
+  rnf (Pow x)    = rnf x \\ witness entailNFDataT x
+  rnf (Dec x)    = rnf x \\ witness entailNFDataT x
+  rnf (CRTr x)   = rnf x \\ witness entailNFDataT x
+  rnf (CRTe x)   = rnf x \\ witness entailNFDataT x
   rnf (Scalar x) = rnf x
   rnf (Sub x)    = rnf x

--- a/test-suite/TensorTests.hs
+++ b/test-suite/TensorTests.hs
@@ -47,13 +47,13 @@ tensorTests =
    ]
 
 
-type TMRCtx t m r = (Tensor t, Fact m, m `Divides` m, CRTrans r, TElt t r, CRTEmbed r, TElt t (CRTExt r), Eq r)
+type TMRCtx t m r = (Tensor t, Fact m, m `Divides` m, CRTrans r, TElt t r, CRTEmbed r, TElt t (CRTExt r))
 
 prop_fmap :: (TMRCtx t m r) => t m r -> Bool
-prop_fmap x = fmapT id x == x \\ witness entailEqT x \\ witness entailIndexT x
+prop_fmap x = fmapT id x == x \\ witness entailFullT x \\ witness entailIndexT x
 
 prop_fmap2 :: (TMRCtx t m r) => t m r -> Bool
-prop_fmap2 x = (fmapT id x) == (fmap id x) \\ witness entailEqT x \\ witness entailIndexT x
+prop_fmap2 x = (fmapT id x) == (fmap id x) \\ witness entailFullT x \\ witness entailIndexT x
 
 -- tests that multiplication in the extension ring matches CRT multiplication
 prop_mul_ext :: forall t m r . (TMRCtx t m r)
@@ -64,10 +64,7 @@ prop_mul_ext x y =
        Nothing -> error "mul have a CRT to call prop_mul_ext"
        Just _ -> (let z = x * y
                       z' = fmapT fromExt $ (fmapT toExt x) * (fmapT toExt y)
-                  in z == z') \\ witness entailEqT x 
-                              \\ witness entailRingT x 
-                              \\ witness entailRingT (fmap toExt x) 
-                              \\ witness entailIndexT x
+                  in z == z') \\ witness entailFullT x \\ witness entailFullT (fmap toExt x) \\ witness entailIndexT x
 
 gInvGTests = testGroup "GInv.G == id" [
   testGroup "Pow basis" $ groupTMR $ wrapTmrToBool prop_ginv_pow,
@@ -77,30 +74,30 @@ gInvGTests = testGroup "GInv.G == id" [
 -- divG . mulG == id in Pow basis
 prop_ginv_pow :: (TMRCtx t m r) => t m r -> Bool
 prop_ginv_pow x = (fromMaybe (error "could not divide by G in prop_ginv_pow") $ 
-  divGPow $ mulGPow x) == x \\ witness entailEqT x
+  divGPow $ mulGPow x) == x \\ witness entailFullT x
 
 -- divG . mulG == id in Dec basis
 prop_ginv_dec :: (TMRCtx t m r) => t m r -> Bool
 prop_ginv_dec x = (fromMaybe (error "could not divide by G in prop_ginv_dec") $ 
-  divGDec $ mulGDec x) == x \\ witness entailEqT x
+  divGDec $ mulGDec x) == x \\ witness entailFullT x
 
 -- divG . mulG == id in CRT basis
 prop_ginv_crt :: (TMRCtx t m r) => t m r -> Bool
 prop_ginv_crt x = fromMaybe (error "no CRT in prop_ginv_crt") $ do
   divGCRT' <- divGCRT
   mulGCRT' <- mulGCRT
-  return $ (divGCRT' $ mulGCRT' x) == x \\ witness entailEqT x
+  return $ (divGCRT' $ mulGCRT' x) == x \\ witness entailFullT x
 
 -- crtInv . crt == id
 prop_crt_inv :: (TMRCtx t m r) => t m r -> Bool
 prop_crt_inv x = fromMaybe (error "no CRT in prop_crt_inv") $ do
   crt' <- crt
   crtInv' <- crtInv
-  return $ (crtInv' $ crt' x) == x \\ witness entailEqT x
+  return $ (crtInv' $ crt' x) == x \\ witness entailFullT x
 
 -- lInv . l == id
 prop_l_inv :: (TMRCtx t m r) => t m r -> Bool
-prop_l_inv x = (lInv $ l x) == x \\ witness entailEqT x
+prop_l_inv x = (lInv $ l x) == x \\ witness entailFullT x
 
 -- scalarCRT = crt . scalarPow
 prop_scalar_crt :: forall t m r . (TMRCtx t m r)
@@ -109,7 +106,7 @@ prop_scalar_crt _ r = fromMaybe (error "no CRT in prop_scalar_crt") $ do
   scalarCRT' <- scalarCRT
   crt' <- crt
   return $ (scalarCRT' r :: t m r) == (crt' $ scalarPow r)
-  \\ proxy entailEqT (Proxy::Proxy (t m r))
+  \\ proxy entailFullT (Proxy::Proxy (t m r))
 
 gCommuteTests = testGroup "G commutes with L" [
   testGroup "Dec basis" $ groupTMR $ wrapTmrToBool prop_g_dec,
@@ -117,14 +114,14 @@ gCommuteTests = testGroup "G commutes with L" [
 
 -- mulGDec == lInv. mulGPow . l
 prop_g_dec :: (TMRCtx t m r) => t m r -> Bool
-prop_g_dec x = (mulGDec x) == (lInv $ mulGPow $ l x) \\ witness entailEqT x
+prop_g_dec x = (mulGDec x) == (lInv $ mulGPow $ l x) \\ witness entailFullT x
 
 prop_g_crt :: (TMRCtx t m r) => t m r -> Bool
 prop_g_crt x = fromMaybe (error "no CRT in prop_g_crt") $ do
   mulGCRT' <- mulGCRT
   crt' <- crt
   crtInv' <- crtInv
-  return $ (mulGCRT' x) == (crt' $ mulGPow $ crtInv' x) \\ witness entailEqT x
+  return $ (mulGCRT' x) == (crt' $ mulGPow $ crtInv' x) \\ witness entailFullT x
 
 type TMRWrapCtx t m r = (TMRCtx t m r, Show (t m r), Arbitrary (t m r), Show r, Arbitrary r)
 
@@ -195,7 +192,7 @@ groupMRExt f = [testProperty "F7/Q29" $ f (Proxy::Proxy '(F7, Zq Q29)),
 
 
 
-type TMM'RCtx t m m' r = (Tensor t, m `Divides` m', TElt t r, Ring r, CRTrans r, Eq r)
+type TMM'RCtx t m m' r = (Tensor t, m `Divides` m', TElt t r, Ring r, CRTrans r)
 
 -- groups related tests
 tremTests = testGroup "Tr.Em == id" [
@@ -206,18 +203,18 @@ tremTests = testGroup "Tr.Em == id" [
 -- tests that twace . embed == id in the Pow basis
 prop_trem_pow :: forall t m m' r . (TMM'RCtx t m m' r)
   => Proxy m' -> t m r -> Bool
-prop_trem_pow _ x = (twacePowDec $ (embedPow x :: t m' r)) == x \\ witness entailEqT x
+prop_trem_pow _ x = (twacePowDec $ (embedPow x :: t m' r)) == x \\ witness entailFullT x
 
 -- tests that twace . embed == id in the Dec basis
 prop_trem_dec :: forall t m m' r . (TMM'RCtx t m m' r)
   => Proxy m' -> t m r -> Bool
-prop_trem_dec _ x = (twacePowDec $ (embedDec x :: t m' r)) == x \\ witness entailEqT x
+prop_trem_dec _ x = (twacePowDec $ (embedDec x :: t m' r)) == x \\ witness entailFullT x
 
 -- tests that twace . embed == id in the CRT basis
 prop_trem_crt :: forall t m m' r . (TMM'RCtx t m m' r)
   => Proxy m' -> t m r -> Bool
 prop_trem_crt _ x = fromMaybe (error "no CRT in prop_trem_crt") $
-  (x==) <$> (twaceCRT <*> (embedCRT <*> pure x :: Maybe (t m' r))) \\ witness entailEqT x
+  (x==) <$> (twaceCRT <*> (embedCRT <*> pure x :: Maybe (t m' r))) \\ witness entailFullT x
 
 embedCommuteTests = testGroup "Em commutes with L" [
   testGroup "Dec basis" $ groupTMM'R $ wrapTmm'rToBool prop_embed_dec,
@@ -226,7 +223,7 @@ embedCommuteTests = testGroup "Em commutes with L" [
 -- embedDec == lInv . embedPow . l
 prop_embed_dec :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> t m r -> Bool
 prop_embed_dec _ x = (embedDec x :: t m' r) == (lInv $ embedPow $ l x) 
-  \\ proxy entailEqT (Proxy::Proxy (t m' r))
+  \\ proxy entailFullT (Proxy::Proxy (t m' r))
 
 -- embedCRT = crt . embedPow . crtInv
 prop_embed_crt :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> t m r -> Bool
@@ -235,7 +232,7 @@ prop_embed_crt _ x = fromMaybe (error "no CRT in prop_embed_crt") $ do
   crtInv' <- crtInv
   embedCRT' <- embedCRT
   return $ (embedCRT' x :: t m' r) == (crt' $ embedPow $ crtInv' x) 
-    \\ proxy entailEqT (Proxy::Proxy (t m' r))
+    \\ proxy entailFullT (Proxy::Proxy (t m' r))
 
 twaceCommuteTests = testGroup "Tw commutes with L" [
   testGroup "Dec basis" $ groupTMM'R $ wrapTm'mrToBool prop_twace_dec,
@@ -244,7 +241,7 @@ twaceCommuteTests = testGroup "Tw commutes with L" [
 -- twacePowDec = lInv . twacePowDec . l
 prop_twace_dec :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m -> t m' r -> Bool
 prop_twace_dec _ x = (twacePowDec x :: t m r) == (lInv $ twacePowDec $ l x)
-  \\ proxy entailEqT (Proxy::Proxy (t m r))
+  \\ proxy entailFullT (Proxy::Proxy (t m r))
 
 -- twaceCRT = crt . twacePowDec . crtInv
 prop_twace_crt :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m -> t m' r -> Bool
@@ -253,7 +250,7 @@ prop_twace_crt _ x = fromMaybe (error "no CRT in prop_trace_crt") $ do
   crt' <- crt
   crtInv' <- crtInv
   return $ (twaceCRT' x :: t m r) == (crt' $ twacePowDec $ crtInv' x)
-    \\ proxy entailEqT (Proxy::Proxy (t m r))
+    \\ proxy entailFullT (Proxy::Proxy (t m r))
 
 twaceInvarTests = testGroup "Twace invariants" [
   testGroup "Tw and Em ID for equal indices" $ groupTMR $ wrapTmrToBool $ prop_twEmID,
@@ -264,12 +261,12 @@ twaceInvarTests = testGroup "Twace invariants" [
   testGroup "Invar2 CRT basis" $ groupTMM'R $ wrapProxyTmm'rToBool prop_twace_invar2_crt
   ]
 
-prop_twEmID :: forall t m r . (Tensor t, TElt t r, CRTrans r, Fact m, m `Divides` m, Eq r) => t m r -> Bool
+prop_twEmID :: forall t m r . (Tensor t, TElt t r, CRTrans r, Fact m, m `Divides` m) => t m r -> Bool
 prop_twEmID x = ((twacePowDec x) == x) &&
                   (((fromMaybe (error "twemid_crt") twaceCRT) x) == x) &&
                   ((embedPow x) == x) &&
                   ((embedDec x) == x) &&
-                  (((fromMaybe (error "twemid_crt") embedCRT) x) == x) \\ witness entailEqT x
+                  (((fromMaybe (error "twemid_crt") embedCRT) x) == x) \\ witness entailFullT x
 
 -- twace mhat'/g' = mhat*totm'/totm/g (Pow basis)
 prop_twace_invar1_pow :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
@@ -280,7 +277,7 @@ prop_twace_invar1_pow _ _ = fromMaybe (error "could not divide by G in prop_twac
       totm' = proxy totientFact (Proxy::Proxy m')
   output :: t m r <- divGPow $ scalarPow $ fromIntegral $ mhat * totm' `div` totm
   input :: t m' r <- divGPow $ scalarPow $ fromIntegral mhat'
-  return $ (twacePowDec input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
+  return $ (twacePowDec input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
 
 -- twace mhat'/g' = mhat*totm'/totm/g (Dec basis)
 prop_twace_invar1_dec :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
@@ -291,7 +288,7 @@ prop_twace_invar1_dec _ _ = fromMaybe (error "could not divide by G in prop_twac
       totm' = proxy totientFact (Proxy::Proxy m')
   output :: t m r <- divGDec $ lInv $ scalarPow $ fromIntegral $ mhat * totm' `div` totm
   input :: t m' r <- divGDec $ lInv $ scalarPow $ fromIntegral mhat'
-  return $ (twacePowDec input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
+  return $ (twacePowDec input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
 
 -- twace mhat'/g' = mhat*totm'/totm/g (CRT basis)
 prop_twace_invar1_crt :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
@@ -307,14 +304,14 @@ prop_twace_invar1_crt _ _ = fromMaybe (error "no CRT in prop_twace_invar1_crt") 
   twaceCRT' <- twaceCRT
   let output :: t m r = divGCRT1 $ scalarCRT1 $ fromIntegral $ mhat * totm' `div` totm
       input :: t m' r = divGCRT2 $ scalarCRT2 $ fromIntegral mhat'
-  return $ (twaceCRT' input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
+  return $ (twaceCRT' input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
 
 -- twace preserves scalars in Pow/Dec basis
 prop_twace_invar2_powdec :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
 prop_twace_invar2_powdec _ _ = 
   let output = scalarPow $ one :: t m r
       input = scalarPow $ one :: t m' r
-  in (twacePowDec input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
+  in (twacePowDec input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
 
 -- twace preserves scalars in Pow/Dec basis
 prop_twace_invar2_crt :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
@@ -323,7 +320,7 @@ prop_twace_invar2_crt _ _ = fromMaybe (error "no CRT in prop_twace_invar2_crt") 
   scalarCRT2 <- scalarCRT
   let input = scalarCRT1 one :: t m' r
       output = scalarCRT2 one :: t m r
-  return $ (twacePowDec input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
+  return $ (twacePowDec input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
 
 type TMM'RWrapCtx t m m' r = (TMM'RCtx t m m' r, Show (t m' r), Show (t m r), Arbitrary (t m' r), Arbitrary (t m r))
 

--- a/test-suite/TensorTests.hs
+++ b/test-suite/TensorTests.hs
@@ -47,13 +47,13 @@ tensorTests =
    ]
 
 
-type TMRCtx t m r = (Tensor t, Fact m, m `Divides` m, CRTrans r, TElt t r, CRTEmbed r, TElt t (CRTExt r))
+type TMRCtx t m r = (Tensor t, Fact m, m `Divides` m, CRTrans r, TElt t r, CRTEmbed r, TElt t (CRTExt r), Eq r)
 
 prop_fmap :: (TMRCtx t m r) => t m r -> Bool
-prop_fmap x = fmapT id x == x \\ witness entailFullT x \\ witness entailIndexT x
+prop_fmap x = fmapT id x == x \\ witness entailEqT x \\ witness entailIndexT x
 
 prop_fmap2 :: (TMRCtx t m r) => t m r -> Bool
-prop_fmap2 x = (fmapT id x) == (fmap id x) \\ witness entailFullT x \\ witness entailIndexT x
+prop_fmap2 x = (fmapT id x) == (fmap id x) \\ witness entailEqT x \\ witness entailIndexT x
 
 -- tests that multiplication in the extension ring matches CRT multiplication
 prop_mul_ext :: forall t m r . (TMRCtx t m r)
@@ -64,7 +64,10 @@ prop_mul_ext x y =
        Nothing -> error "mul have a CRT to call prop_mul_ext"
        Just _ -> (let z = x * y
                       z' = fmapT fromExt $ (fmapT toExt x) * (fmapT toExt y)
-                  in z == z') \\ witness entailFullT x \\ witness entailFullT (fmap toExt x) \\ witness entailIndexT x
+                  in z == z') \\ witness entailEqT x 
+                              \\ witness entailRingT x 
+                              \\ witness entailRingT (fmap toExt x) 
+                              \\ witness entailIndexT x
 
 gInvGTests = testGroup "GInv.G == id" [
   testGroup "Pow basis" $ groupTMR $ wrapTmrToBool prop_ginv_pow,
@@ -74,30 +77,30 @@ gInvGTests = testGroup "GInv.G == id" [
 -- divG . mulG == id in Pow basis
 prop_ginv_pow :: (TMRCtx t m r) => t m r -> Bool
 prop_ginv_pow x = (fromMaybe (error "could not divide by G in prop_ginv_pow") $ 
-  divGPow $ mulGPow x) == x \\ witness entailFullT x
+  divGPow $ mulGPow x) == x \\ witness entailEqT x
 
 -- divG . mulG == id in Dec basis
 prop_ginv_dec :: (TMRCtx t m r) => t m r -> Bool
 prop_ginv_dec x = (fromMaybe (error "could not divide by G in prop_ginv_dec") $ 
-  divGDec $ mulGDec x) == x \\ witness entailFullT x
+  divGDec $ mulGDec x) == x \\ witness entailEqT x
 
 -- divG . mulG == id in CRT basis
 prop_ginv_crt :: (TMRCtx t m r) => t m r -> Bool
 prop_ginv_crt x = fromMaybe (error "no CRT in prop_ginv_crt") $ do
   divGCRT' <- divGCRT
   mulGCRT' <- mulGCRT
-  return $ (divGCRT' $ mulGCRT' x) == x \\ witness entailFullT x
+  return $ (divGCRT' $ mulGCRT' x) == x \\ witness entailEqT x
 
 -- crtInv . crt == id
 prop_crt_inv :: (TMRCtx t m r) => t m r -> Bool
 prop_crt_inv x = fromMaybe (error "no CRT in prop_crt_inv") $ do
   crt' <- crt
   crtInv' <- crtInv
-  return $ (crtInv' $ crt' x) == x \\ witness entailFullT x
+  return $ (crtInv' $ crt' x) == x \\ witness entailEqT x
 
 -- lInv . l == id
 prop_l_inv :: (TMRCtx t m r) => t m r -> Bool
-prop_l_inv x = (lInv $ l x) == x \\ witness entailFullT x
+prop_l_inv x = (lInv $ l x) == x \\ witness entailEqT x
 
 -- scalarCRT = crt . scalarPow
 prop_scalar_crt :: forall t m r . (TMRCtx t m r)
@@ -106,7 +109,7 @@ prop_scalar_crt _ r = fromMaybe (error "no CRT in prop_scalar_crt") $ do
   scalarCRT' <- scalarCRT
   crt' <- crt
   return $ (scalarCRT' r :: t m r) == (crt' $ scalarPow r)
-  \\ proxy entailFullT (Proxy::Proxy (t m r))
+  \\ proxy entailEqT (Proxy::Proxy (t m r))
 
 gCommuteTests = testGroup "G commutes with L" [
   testGroup "Dec basis" $ groupTMR $ wrapTmrToBool prop_g_dec,
@@ -114,14 +117,14 @@ gCommuteTests = testGroup "G commutes with L" [
 
 -- mulGDec == lInv. mulGPow . l
 prop_g_dec :: (TMRCtx t m r) => t m r -> Bool
-prop_g_dec x = (mulGDec x) == (lInv $ mulGPow $ l x) \\ witness entailFullT x
+prop_g_dec x = (mulGDec x) == (lInv $ mulGPow $ l x) \\ witness entailEqT x
 
 prop_g_crt :: (TMRCtx t m r) => t m r -> Bool
 prop_g_crt x = fromMaybe (error "no CRT in prop_g_crt") $ do
   mulGCRT' <- mulGCRT
   crt' <- crt
   crtInv' <- crtInv
-  return $ (mulGCRT' x) == (crt' $ mulGPow $ crtInv' x) \\ witness entailFullT x
+  return $ (mulGCRT' x) == (crt' $ mulGPow $ crtInv' x) \\ witness entailEqT x
 
 type TMRWrapCtx t m r = (TMRCtx t m r, Show (t m r), Arbitrary (t m r), Show r, Arbitrary r)
 
@@ -192,7 +195,7 @@ groupMRExt f = [testProperty "F7/Q29" $ f (Proxy::Proxy '(F7, Zq Q29)),
 
 
 
-type TMM'RCtx t m m' r = (Tensor t, m `Divides` m', TElt t r, Ring r, CRTrans r)
+type TMM'RCtx t m m' r = (Tensor t, m `Divides` m', TElt t r, Ring r, CRTrans r, Eq r)
 
 -- groups related tests
 tremTests = testGroup "Tr.Em == id" [
@@ -203,18 +206,18 @@ tremTests = testGroup "Tr.Em == id" [
 -- tests that twace . embed == id in the Pow basis
 prop_trem_pow :: forall t m m' r . (TMM'RCtx t m m' r)
   => Proxy m' -> t m r -> Bool
-prop_trem_pow _ x = (twacePowDec $ (embedPow x :: t m' r)) == x \\ witness entailFullT x
+prop_trem_pow _ x = (twacePowDec $ (embedPow x :: t m' r)) == x \\ witness entailEqT x
 
 -- tests that twace . embed == id in the Dec basis
 prop_trem_dec :: forall t m m' r . (TMM'RCtx t m m' r)
   => Proxy m' -> t m r -> Bool
-prop_trem_dec _ x = (twacePowDec $ (embedDec x :: t m' r)) == x \\ witness entailFullT x
+prop_trem_dec _ x = (twacePowDec $ (embedDec x :: t m' r)) == x \\ witness entailEqT x
 
 -- tests that twace . embed == id in the CRT basis
 prop_trem_crt :: forall t m m' r . (TMM'RCtx t m m' r)
   => Proxy m' -> t m r -> Bool
 prop_trem_crt _ x = fromMaybe (error "no CRT in prop_trem_crt") $
-  (x==) <$> (twaceCRT <*> (embedCRT <*> pure x :: Maybe (t m' r))) \\ witness entailFullT x
+  (x==) <$> (twaceCRT <*> (embedCRT <*> pure x :: Maybe (t m' r))) \\ witness entailEqT x
 
 embedCommuteTests = testGroup "Em commutes with L" [
   testGroup "Dec basis" $ groupTMM'R $ wrapTmm'rToBool prop_embed_dec,
@@ -223,7 +226,7 @@ embedCommuteTests = testGroup "Em commutes with L" [
 -- embedDec == lInv . embedPow . l
 prop_embed_dec :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> t m r -> Bool
 prop_embed_dec _ x = (embedDec x :: t m' r) == (lInv $ embedPow $ l x) 
-  \\ proxy entailFullT (Proxy::Proxy (t m' r))
+  \\ proxy entailEqT (Proxy::Proxy (t m' r))
 
 -- embedCRT = crt . embedPow . crtInv
 prop_embed_crt :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> t m r -> Bool
@@ -232,7 +235,7 @@ prop_embed_crt _ x = fromMaybe (error "no CRT in prop_embed_crt") $ do
   crtInv' <- crtInv
   embedCRT' <- embedCRT
   return $ (embedCRT' x :: t m' r) == (crt' $ embedPow $ crtInv' x) 
-    \\ proxy entailFullT (Proxy::Proxy (t m' r))
+    \\ proxy entailEqT (Proxy::Proxy (t m' r))
 
 twaceCommuteTests = testGroup "Tw commutes with L" [
   testGroup "Dec basis" $ groupTMM'R $ wrapTm'mrToBool prop_twace_dec,
@@ -241,7 +244,7 @@ twaceCommuteTests = testGroup "Tw commutes with L" [
 -- twacePowDec = lInv . twacePowDec . l
 prop_twace_dec :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m -> t m' r -> Bool
 prop_twace_dec _ x = (twacePowDec x :: t m r) == (lInv $ twacePowDec $ l x)
-  \\ proxy entailFullT (Proxy::Proxy (t m r))
+  \\ proxy entailEqT (Proxy::Proxy (t m r))
 
 -- twaceCRT = crt . twacePowDec . crtInv
 prop_twace_crt :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m -> t m' r -> Bool
@@ -250,7 +253,7 @@ prop_twace_crt _ x = fromMaybe (error "no CRT in prop_trace_crt") $ do
   crt' <- crt
   crtInv' <- crtInv
   return $ (twaceCRT' x :: t m r) == (crt' $ twacePowDec $ crtInv' x)
-    \\ proxy entailFullT (Proxy::Proxy (t m r))
+    \\ proxy entailEqT (Proxy::Proxy (t m r))
 
 twaceInvarTests = testGroup "Twace invariants" [
   testGroup "Tw and Em ID for equal indices" $ groupTMR $ wrapTmrToBool $ prop_twEmID,
@@ -261,12 +264,12 @@ twaceInvarTests = testGroup "Twace invariants" [
   testGroup "Invar2 CRT basis" $ groupTMM'R $ wrapProxyTmm'rToBool prop_twace_invar2_crt
   ]
 
-prop_twEmID :: forall t m r . (Tensor t, TElt t r, CRTrans r, Fact m, m `Divides` m) => t m r -> Bool
+prop_twEmID :: forall t m r . (Tensor t, TElt t r, CRTrans r, Fact m, m `Divides` m, Eq r) => t m r -> Bool
 prop_twEmID x = ((twacePowDec x) == x) &&
                   (((fromMaybe (error "twemid_crt") twaceCRT) x) == x) &&
                   ((embedPow x) == x) &&
                   ((embedDec x) == x) &&
-                  (((fromMaybe (error "twemid_crt") embedCRT) x) == x) \\ witness entailFullT x
+                  (((fromMaybe (error "twemid_crt") embedCRT) x) == x) \\ witness entailEqT x
 
 -- twace mhat'/g' = mhat*totm'/totm/g (Pow basis)
 prop_twace_invar1_pow :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
@@ -277,7 +280,7 @@ prop_twace_invar1_pow _ _ = fromMaybe (error "could not divide by G in prop_twac
       totm' = proxy totientFact (Proxy::Proxy m')
   output :: t m r <- divGPow $ scalarPow $ fromIntegral $ mhat * totm' `div` totm
   input :: t m' r <- divGPow $ scalarPow $ fromIntegral mhat'
-  return $ (twacePowDec input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
+  return $ (twacePowDec input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
 
 -- twace mhat'/g' = mhat*totm'/totm/g (Dec basis)
 prop_twace_invar1_dec :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
@@ -288,7 +291,7 @@ prop_twace_invar1_dec _ _ = fromMaybe (error "could not divide by G in prop_twac
       totm' = proxy totientFact (Proxy::Proxy m')
   output :: t m r <- divGDec $ lInv $ scalarPow $ fromIntegral $ mhat * totm' `div` totm
   input :: t m' r <- divGDec $ lInv $ scalarPow $ fromIntegral mhat'
-  return $ (twacePowDec input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
+  return $ (twacePowDec input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
 
 -- twace mhat'/g' = mhat*totm'/totm/g (CRT basis)
 prop_twace_invar1_crt :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
@@ -304,14 +307,14 @@ prop_twace_invar1_crt _ _ = fromMaybe (error "no CRT in prop_twace_invar1_crt") 
   twaceCRT' <- twaceCRT
   let output :: t m r = divGCRT1 $ scalarCRT1 $ fromIntegral $ mhat * totm' `div` totm
       input :: t m' r = divGCRT2 $ scalarCRT2 $ fromIntegral mhat'
-  return $ (twaceCRT' input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
+  return $ (twaceCRT' input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
 
 -- twace preserves scalars in Pow/Dec basis
 prop_twace_invar2_powdec :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
 prop_twace_invar2_powdec _ _ = 
   let output = scalarPow $ one :: t m r
       input = scalarPow $ one :: t m' r
-  in (twacePowDec input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
+  in (twacePowDec input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
 
 -- twace preserves scalars in Pow/Dec basis
 prop_twace_invar2_crt :: forall t m m' r . (TMM'RCtx t m m' r) => Proxy m' -> Proxy (t m r) -> Bool
@@ -320,7 +323,7 @@ prop_twace_invar2_crt _ _ = fromMaybe (error "no CRT in prop_twace_invar2_crt") 
   scalarCRT2 <- scalarCRT
   let input = scalarCRT1 one :: t m' r
       output = scalarCRT2 one :: t m r
-  return $ (twacePowDec input) == output \\ proxy entailFullT (Proxy::Proxy (t m r))
+  return $ (twacePowDec input) == output \\ proxy entailEqT (Proxy::Proxy (t m r))
 
 type TMM'RWrapCtx t m m' r = (TMM'RCtx t m m' r, Show (t m' r), Show (t m r), Arbitrary (t m' r), Arbitrary (t m r))
 


### PR DESCRIPTION
Changes:
2 new derived standalone instances for NFData (see https://ghc.haskell.org/trac/ghc/ticket/11008)
New constraints in Tensor interface
UCyc: just a few more constraints, much weaker entailments