### PR TITLE
Add a stck.yaml file for lts-3.11

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,46 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/master/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.11
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+- arithmoi-0.4.1.3
+- numeric-prelude-0.4.2
+- storable-record-0.0.3
+- storable-tuple-0.0.2
+- tagged-transformer-0.8
+- type-natural-0.3.0.0
+- equational-reasoning-0.2.0.7
+- monomorphic-0.0.3.3
+- non-negative-0.1.1
+- utility-ht-0.0.11
+
+# (RRN) In stackage, but force a different version:
+- singletons-2.0.1
+- vector-0.11.0.0
+- repa-3.4.0.2
+# This one is held back to an older version:
+- semigroupoids-4.3
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
This just makes things easy and reproducible to build.  One command should build it:

```bash
stack --install-ghc build
```

The stack binary is available prebuilt and is a single, small download -- https://www.stackage.org/.