### PR TITLE
Upgrade to stack lst-17.5 resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,3 @@ lol-cpp/lib
 **/.DS_Store
 *.lock
 *.bak
-lol/lol.cabal
-lol-apps/lol-apps.cabal
-lol-cpp/lol-cpp.cabal

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ sudo: required
 
 # Do not choose a language; we provide our own build tools.
 language: generic
-dist: trusty
+dist: focal
 
 # Caching so the next build will be fast too.
 cache:

--- a/lol-apps/Crypto/Lol/Applications/Benchmarks/KHPRFBenches.hs
+++ b/lol-apps/Crypto/Lol/Applications/Benchmarks/KHPRFBenches.hs
@@ -33,6 +33,8 @@ import Crypto.Lol.Benchmarks                     (ArgType, Benchmark,
 import Crypto.Lol.Reflects
 import Crypto.Lol.Types
 
+import Data.Singletons
+
 type M = F64
 type N = 1
 type Q = 256

--- a/lol-apps/Crypto/Lol/Applications/KeyHomomorphicPRF.hs
+++ b/lol-apps/Crypto/Lol/Applications/KeyHomomorphicPRF.hs
@@ -11,25 +11,34 @@ Portability : POSIX
 Key-homomorphic PRF from <http://web.eecs.umich.edu/~cpeikert/pubs/kh-prf.pdf [BP14]>.
 -}
 
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NoImplicitPrelude     #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ConstraintKinds           #-}
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE DefaultSignatures         #-}
+{-# LANGUAGE EmptyCase                 #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE InstanceSigs              #-}
+{-# LANGUAGE KindSignatures            #-}
+{-# LANGUAGE MultiParamTypeClasses     #-}
+{-# LANGUAGE NoCUSKs                   #-}
+{-# LANGUAGE NoImplicitPrelude         #-}
+{-# LANGUAGE NoStarIsType              #-}
+{-# LANGUAGE PolyKinds                 #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneDeriving        #-}
+{-# LANGUAGE StandaloneKindSignatures  #-}
+{-# LANGUAGE TemplateHaskell           #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
+{-# LANGUAGE UndecidableInstances      #-}
 
 module Crypto.Lol.Applications.KeyHomomorphicPRF
-( FBT(..), SFBT, SizeFBT, FBTC, singFBT
+( FBT(..), SFBT(..), SizeFBT, FBTC, singFBT
 , PRFKey, PRFParams, PRFState
 , genKey, genParams, prf, prfState, prfAmortized, run, runT
 , Vector, BitString

--- a/lol-apps/Crypto/Lol/Applications/Tests/Default.hs
+++ b/lol-apps/Crypto/Lol/Applications/Tests/Default.hs
@@ -31,9 +31,10 @@ import Crypto.Lol.Tests
 import Data.Proxy
 
 defaultAppsTests ::
-  (forall m r . (Fact m, Show r, Eq r) => (Show (t m r), Eq (t m r)),
-   _)
-  => Proxy t -> Proxy gad -> [Test]
+  ( forall m r. (Fact m, Show r, Eq r) => Show (t m r)
+  , forall m r. (Fact m, Show r, Eq r) => Eq (t m r)
+  , _
+  ) => Proxy t -> Proxy gad -> [Test]
 defaultAppsTests pt pgad  =
   [testGroup "BGV" $ ($ pt) <$> [
     bgvTests (Proxy::Proxy '(F7, F7, Zq 2,Zq (19393921 ** 18869761))),

--- a/lol-apps/lol-apps.cabal
+++ b/lol-apps/lol-apps.cabal
@@ -1,0 +1,85 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           lol-apps
+version:        0.3.0.1
+synopsis:       Lattice-based cryptographic applications using <https://hackage.haskell.org/package/lol lol>.
+description:    This library contains example cryptographic applications built using <https://hackage.haskell.org/package/lol Lol>, a general-purpose library for ring-based lattice cryptography.
+category:       Crypto
+stability:      experimental
+homepage:       https://github.com/cpeikert/lol#readme
+bug-reports:    https://github.com/cpeikert/lol/issues
+author:         Eric Crockett <ecrockett0@gmail.com>,
+                Chris Peikert <cpeikert@alum.mit.edu>
+maintainer:     Eric Crockett <ecrockett@gmail.com>,
+                Chad Sharp <cmlsharp@umich.edu>
+copyright:      Eric Crockett,
+                Chris Peikert
+license:        GPL-3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README
+    CHANGES.md
+    BGV.proto
+
+source-repository head
+  type: git
+  location: https://github.com/cpeikert/lol
+
+flag llvm
+  description: Compile via LLVM. This produces much better object code, but you need to have the LLVM compiler installed.
+  manual: False
+  default: False
+
+flag opt
+  description: Turn on library optimizations
+  manual: False
+  default: True
+
+library
+  exposed-modules:
+      Crypto.Lol.Applications.KeyHomomorphicPRF
+      Crypto.Lol.Applications.SymmBGV
+      Crypto.Proto.BGV
+      Crypto.Proto.BGV.KSHint
+      Crypto.Proto.BGV.RqPolynomial
+      Crypto.Proto.BGV.SecretKey
+      Crypto.Proto.BGV.TunnelHint
+      Crypto.Lol.Applications.Tests
+      Crypto.Lol.Applications.Benchmarks
+      Crypto.Lol.Applications.Examples
+  other-modules:
+      Crypto.Lol.Applications.Tests.BGVTests
+      Crypto.Lol.Applications.Tests.Default
+      Crypto.Lol.Applications.Benchmarks.KHPRFBenches
+      Crypto.Lol.Applications.Benchmarks.BGVBenches
+      Crypto.Lol.Applications.Benchmarks.Default
+      Crypto.Lol.Applications.Examples.KHPRF
+      Crypto.Lol.Applications.Examples.SymmBGV
+  build-depends:
+      DRBG >=0.5.5 && <0.6
+    , MonadRandom >=0.5.1 && <0.6
+    , QuickCheck >=2.13.2 && <2.15
+    , base >=4.14.0 && <4.15
+    , constraints >=0.10.1 && <0.14
+    , containers >=0.6.0 && <0.7
+    , crypto-api >=0.13.3 && <0.14
+    , deepseq >=1.4.4 && <1.5
+    , filepath >=1.4.2 && <1.5
+    , lol >=0.7.0.0 && <0.8
+    , mtl >=2.2.2 && <2.3
+    , numeric-prelude >=0.4.3 && <0.5
+    , options >=1.2.1 && <1.3
+    , protocol-buffers >=2.4.13 && <2.5
+    , protocol-buffers-descriptor >=2.4.13 && <2.5
+    , singletons ==2.7.*
+    , split >=0.2.3 && <0.3
+    , test-framework >=0.8.2 && <0.9
+    , time >=1.8.0 && <1.12
+  if flag(llvm)
+    ghc-options: -fllvm -optlo-O3 -pgmlo opt
+  default-language: Haskell2010

--- a/lol-apps/package.yaml
+++ b/lol-apps/package.yaml
@@ -1,7 +1,7 @@
 _common: !include "./common.yaml"
 
 name: lol-apps
-version: 0.3.0.0
+version: 0.3.0.1
 synopsis: Lattice-based cryptographic applications using <https://hackage.haskell.org/package/lol lol>.
 extra-source-files:
   - README
@@ -45,20 +45,20 @@ library:
   dependencies:
     - lol >= 0.7.0.0 && < 0.8
     - DRBG >= 0.5.5 && < 0.6
-    - base >= 4.12.0 && < 4.13
+    - base >= 4.14.0 && < 4.15
     - deepseq >= 1.4.4 && < 1.5
     - containers >= 0.6.0 && < 0.7
     - crypto-api >= 0.13.3 && < 0.14
-    - time >= 1.8.0 && < 1.9
+    - time >= 1.8.0 && < 1.12
     - filepath >= 1.4.2 && < 1.5
     - mtl >= 2.2.2 && < 2.3
     - MonadRandom >= 0.5.1 && < 0.6
-    - QuickCheck >= 2.13.2 && < 2.14
-    - constraints >= 0.10 && < 0.11
+    - QuickCheck >= 2.13.2 && < 2.15
+    - constraints >= 0.10.1 && < 0.14
     - numeric-prelude >= 0.4.3 && < 0.5
     - protocol-buffers >= 2.4.13 && < 2.5
     - protocol-buffers-descriptor >= 2.4.13 && < 2.5
-    - singletons >= 2.5.1 && < 2.6
+    - singletons >= 2.7 && < 2.8
     - test-framework >= 0.8.2 && < 0.9
     - options >= 1.2.1 && < 1.3
     - split >= 0.2.3 && < 0.3

--- a/lol-cpp/lol-cpp.cabal
+++ b/lol-cpp/lol-cpp.cabal
@@ -1,0 +1,151 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           lol-cpp
+version:        0.2.0.1
+synopsis:       A fast C++ backend for <https://hackage.haskell.org/package/lol lol>.
+description:    Λ ⚬ λ (Lol) is a general-purpose library for ring-based lattice cryptography. This package provides a C++ implementation of Lol's Tensor interface.
+category:       Crypto
+stability:      experimental
+homepage:       https://github.com/cpeikert/lol#readme
+bug-reports:    https://github.com/cpeikert/lol/issues
+author:         Eric Crockett <ecrockett0@gmail.com>,
+                Chris Peikert <cpeikert@alum.mit.edu>
+maintainer:     Eric Crockett <ecrockett@gmail.com>,
+                Chad Sharp <cmlsharp@umich.edu>
+copyright:      Eric Crockett,
+                Chris Peikert
+license:        GPL-3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README
+    CHANGES.md
+    Crypto/Lol/Cyclotomic/Tensor/CPP/common.h
+    Crypto/Lol/Cyclotomic/Tensor/CPP/tensor.h
+    Crypto/Lol/Cyclotomic/Tensor/CPP/types.h
+    Crypto/Lol/Cyclotomic/Tensor/CPP/common.cpp
+    Crypto/Lol/Cyclotomic/Tensor/CPP/crt.cpp
+    Crypto/Lol/Cyclotomic/Tensor/CPP/g.cpp
+    Crypto/Lol/Cyclotomic/Tensor/CPP/l.cpp
+    Crypto/Lol/Cyclotomic/Tensor/CPP/mul.cpp
+    Crypto/Lol/Cyclotomic/Tensor/CPP/norm.cpp
+    Crypto/Lol/Cyclotomic/Tensor/CPP/random.cpp
+    Crypto/Lol/Cyclotomic/Tensor/CPP/rrq.cpp
+    Crypto/Lol/Cyclotomic/Tensor/CPP/zq.cpp
+
+source-repository head
+  type: git
+  location: https://github.com/cpeikert/lol
+
+flag llvm
+  description: Compile via LLVM. This produces much better object code, but you need to have the LLVM compiler installed.
+  manual: False
+  default: False
+
+flag opt
+  description: Turn on library optimizations
+  manual: False
+  default: True
+
+flag with-apps
+  description: When this flag is enabled, lol-apps tests and benchmarks are buildable.
+  manual: False
+  default: True
+
+flag with-execs
+  description: When this flag and `with-apps` are both enabled, the lol-apps executables are buildable
+  manual: False
+  default: False
+
+library
+  exposed-modules:
+      Crypto.Lol.Cyclotomic.Tensor.CPP
+  other-modules:
+      Crypto.Lol.Cyclotomic.Tensor.CPP.Backend
+      Crypto.Lol.Cyclotomic.Tensor.CPP.Extension
+      Crypto.Lol.Cyclotomic.Tensor.CPP.Instances
+  cc-options: -std=c++11 -O3
+  include-dirs:
+      Crypto/Lol/Cyclotomic/Tensor/CPP
+  c-sources:
+      Crypto/Lol/Cyclotomic/Tensor/CPP/common.cpp
+      Crypto/Lol/Cyclotomic/Tensor/CPP/crt.cpp
+      Crypto/Lol/Cyclotomic/Tensor/CPP/g.cpp
+      Crypto/Lol/Cyclotomic/Tensor/CPP/l.cpp
+      Crypto/Lol/Cyclotomic/Tensor/CPP/mul.cpp
+      Crypto/Lol/Cyclotomic/Tensor/CPP/norm.cpp
+      Crypto/Lol/Cyclotomic/Tensor/CPP/random.cpp
+      Crypto/Lol/Cyclotomic/Tensor/CPP/rrq.cpp
+      Crypto/Lol/Cyclotomic/Tensor/CPP/zq.cpp
+  build-depends:
+      MonadRandom >=0.5.1 && <0.6
+    , base >=4.14.0 && <4.15
+    , constraints >=0.10 && <0.14
+    , deepseq >=1.4.4 && <1.5
+    , lol >=0.7.0.0 && <0.8
+    , mtl >=2.2.2 && <2.3
+    , numeric-prelude >=0.4.3 && <0.5
+    , reflection >=2.1.5 && <2.2
+    , vector >=0.12.0 && <0.13
+  if flag(llvm)
+    ghc-options: -fllvm -optlo-O3 -pgmlo opt
+  default-language: Haskell2010
+
+test-suite test-lol-apps-cpp
+  type: exitcode-stdio-1.0
+  main-is: TestAppsCPPMain.hs
+  other-modules:
+      TestLolCPPMain
+      Paths_lol_cpp
+  hs-source-dirs:
+      tests
+  ghc-options: -main-is TestAppsCPPMain
+  build-depends:
+      base
+    , lol >=0.7.0.0 && <0.8
+    , lol-apps ==0.3.*
+    , lol-cpp
+    , test-framework
+  if flag(llvm)
+    ghc-options: -fllvm -optlo-O3 -pgmlo opt
+  if !flag(with-apps)
+    buildable: False
+  default-language: Haskell2010
+
+benchmark bench-lol-apps-cpp
+  type: exitcode-stdio-1.0
+  main-is: BenchAppsCPPMain.hs
+  hs-source-dirs:
+      benchmarks
+  ghc-options: -main-is BenchAppsCPPMain
+  build-depends:
+      DRBG
+    , MonadRandom
+    , base
+    , lol >=0.7.0.0 && <0.8
+    , lol-apps ==0.3.*
+    , lol-cpp
+  if flag(llvm)
+    ghc-options: -fllvm -optlo-O3 -pgmlo opt
+  if !flag(with-apps)
+    buildable: False
+  default-language: Haskell2010
+
+benchmark bench-lol-cpp
+  type: exitcode-stdio-1.0
+  main-is: BenchLolCPPMain.hs
+  hs-source-dirs:
+      benchmarks
+  ghc-options: -main-is BenchLolCPPMain
+  build-depends:
+      DRBG
+    , base
+    , lol >=0.7.0.0 && <0.8
+    , lol-cpp
+  if flag(llvm)
+    ghc-options: -fllvm -optlo-O3 -pgmlo opt
+  default-language: Haskell2010

--- a/lol-cpp/package.yaml
+++ b/lol-cpp/package.yaml
@@ -1,7 +1,7 @@
 _common: !include "./common.yaml"
 
 name: lol-cpp
-version: 0.2.0.0
+version: 0.2.0.1
 synopsis:            A fast C++ backend for <https://hackage.haskell.org/package/lol lol>.
 category:            Crypto
 stability:           experimental
@@ -51,10 +51,10 @@ library:
     - Crypto.Lol.Cyclotomic.Tensor.CPP.Instances
   dependencies:
     - MonadRandom >= 0.5.1 && < 0.6
-    - base >= 4.12.0 && < 4.13
+    - base >= 4.14.0 && < 4.15
     - mtl >= 2.2.2 && < 2.3
     - deepseq >= 1.4.4 && < 1.5
-    - constraints >= 0.10 && < 0.11
+    - constraints >= 0.10 && < 0.14
     - vector >= 0.12.0 && < 0.13
     - numeric-prelude >= 0.4.3 && < 0.5
     - reflection >= 2.1.5 && < 2.2

--- a/lol/Crypto/Lol/Cyclotomic/Cyc.hs
+++ b/lol/Crypto/Lol/Cyclotomic/Cyc.hs
@@ -496,7 +496,7 @@ instance (GFCtx fp d, Fact m, CRTElt t fp, Module (GF fp d) (t m fp))
   -- Can use any r-basis to define module mult, but must be
   -- consistent. We use powerful basis.
   r *> (Pow v) = Pow $ r *> v
-  r *> x = r *> toPow' x
+  r *> x       = r *> toPow' x
 
 deriving instance (Ring (GF (ZqBasic q z) d),
                    Module (GF (ZqBasic q z) d) (CycG t m (ZqBasic q z)))
@@ -994,9 +994,13 @@ instance (Random (t m (RRq q r)))
 
 -----
 
-instance (Show r, Fact m, r' ~ CRTExt r, -- workaround TF in q'd constraint
-          forall m' . Fact m' => (Show (t m' r), Show (t m' r')))
-  => Show (CycG t m r) where
+instance
+  ( Show r
+  , Fact m
+  , r' ~ CRTExt r -- workaround TF in q'd constraint
+  , forall m'. Fact m' => Show (t m' r)
+  , forall m'. Fact m' => Show (t m' r')
+  ) => Show (CycG t m r) where
   show (Pow x)         = "Cyc.Pow "    ++ show x
   show (Dec x)         = "Cyc.Dec "    ++ show x
   show (CRT (Left x))  = "Cyc.CRT "    ++ show x
@@ -1015,9 +1019,13 @@ deriving instance (Show (t m (RRq q r))) => Show (Cyc t m (RRq q r))
 
 -----
 
-instance (NFData r, Fact m, r' ~ CRTExt r,
-          forall m' . Fact m' => (NFData (t m' r), NFData (t m' r')))
-  => NFData (CycG t m r) where
+instance
+  ( NFData r
+  , Fact m
+  , r' ~ CRTExt r
+  , forall m'. Fact m' => NFData (t m' r)
+  , forall m'. Fact m' => NFData (t m' r')
+  ) => NFData (CycG t m r) where
   rnf (Pow u)    = rnf u
   rnf (Dec u)    = rnf u
   rnf (CRT u)    = rnf u

--- a/lol/Crypto/Lol/Cyclotomic/Tensor.hs
+++ b/lol/Crypto/Lol/Cyclotomic/Tensor.hs
@@ -87,9 +87,13 @@ import qualified Data.Vector.Unboxed     as U
 -- inputs for each method is determined by the linear transform it
 -- implements.
 
-class (forall m . Fact m => (Applicative (t m), Traversable (t m)),
-       IFunctor t, IFElt t r, Additive r)
-  => TensorPowDec t r where
+class
+  ( forall m. Fact m => Applicative (t m)
+  , forall m. Fact m => Traversable (t m)
+  , IFunctor t
+  , IFElt t r
+  , Additive r
+  ) => TensorPowDec t r where
 
   -- | Convert a scalar to a tensor in the powerful basis.
   scalarPow :: Fact m => r -> t m r

--- a/lol/Crypto/Lol/FactoredDefs.hs
+++ b/lol/Crypto/Lol/FactoredDefs.hs
@@ -12,23 +12,28 @@ This sub-module exists only because we can't define and use
 template Haskell splices in the same module.
 -}
 
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE InstanceSigs          #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NoStarIsType          #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE AllowAmbiguousTypes       #-}
+{-# LANGUAGE ConstraintKinds           #-}
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE DefaultSignatures         #-}
+{-# LANGUAGE EmptyCase                 #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE InstanceSigs              #-}
+{-# LANGUAGE KindSignatures            #-}
+{-# LANGUAGE NoCUSKs                   #-}
+{-# LANGUAGE NoStarIsType              #-}
+{-# LANGUAGE PolyKinds                 #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneKindSignatures  #-}
+{-# LANGUAGE TemplateHaskell           #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
+{-# LANGUAGE UndecidableInstances      #-}
 
 {-# OPTIONS_GHC -fno-warn-unused-binds          #-}
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
@@ -39,7 +44,7 @@ module Crypto.Lol.FactoredDefs
   Factored, SFactored, Fact, fType, fDec
 , reifyFact, reifyFactI, intToFact
 -- * Prime powers
-, PrimePower(..), SPrimePower, Sing(SPP), PPow, ppType, ppDec
+, PrimePower(..), SPrimePower(..), PPow, ppType, ppDec
 , reifyPPow, reifyPPowI
 -- * Primes
 , PrimeBin, SPrimeBin, Prime, pType, pDec

--- a/lol/Crypto/Lol/PosBinDefs.hs
+++ b/lol/Crypto/Lol/PosBinDefs.hs
@@ -15,33 +15,40 @@ This sub-module exists only because we can't define and use
 template Haskell splices in the same module.
 -}
 
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE EmptyCase             #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE InstanceSigs          #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RebindableSyntax      #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ConstraintKinds           #-}
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE DefaultSignatures         #-}
+{-# LANGUAGE EmptyCase                 #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE InstanceSigs              #-}
+{-# LANGUAGE KindSignatures            #-}
+{-# LANGUAGE NoCUSKs                   #-}
+{-# LANGUAGE NoStarIsType              #-}
+{-# LANGUAGE PolyKinds                 #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RebindableSyntax          #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneKindSignatures  #-}
+{-# LANGUAGE TemplateHaskell           #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
+{-# LANGUAGE UndecidableInstances      #-}
 
 {-# OPTIONS_GHC -fno-warn-duplicate-exports     #-}
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Crypto.Lol.PosBinDefs
 ( -- * Positive naturals in Peano representation
-  Pos(..), Sing(SO, SS), SPos, PosC, posType, posDec
+  Pos(..), SPos(..), PosC, posType, posDec
 , reifyPos, reifyPosI, posToInt, intToPos
 , addPos, sAddPos, AddPos, subPos, sSubPos, SubPos
 , OSym0, SSym0, SSym1, AddPosSym0, AddPosSym1, SubPosSym0, SubPosSym1
   -- * Positive naturals in binary representation
-, Bin(..), Sing(SB1, SD0, SD1), SBin, BinC, binType, binDec
+, Bin(..), SBin(..), BinC, binType, binDec
 , reifyBin, reifyBinI, binToInt, intToBin
 , B1Sym0, D0Sym0, D0Sym1, D1Sym0, D1Sym1
   -- * Miscellaneous
@@ -55,6 +62,7 @@ import Language.Haskell.TH
 
 import Algebra.ToInteger as ToInteger
 import NumericPrelude
+import Prelude           (fail)
 
 singletons [d|
             -- Positive naturals (1, 2, ...) in Peano representation.

--- a/lol/Crypto/Lol/Types/FiniteField.hs
+++ b/lol/Crypto/Lol/Types/FiniteField.hs
@@ -106,7 +106,7 @@ instance (GFCtx fp d) => Field.C (GF fp d) where
 
 instance (GFCtx fp d, NFData fp) => CRTrans Maybe (GF fp d) where
   -- https://ghc.haskell.org/trac/ghc/wiki/Migration/8.2#KindgeneralizationandMonoLocalBinds
-  crtInfo :: forall (m :: k) . (Reflects m Int) => TaggedT m Maybe (CRTInfo (GF fp d))
+  crtInfo :: forall k (m :: k) . (Reflects m Int) => TaggedT m Maybe (CRTInfo (GF fp d))
   {-# INLINABLE crtInfo #-}
   crtInfo = tagT $ (,) <$> omegaPow <*> scalarInv
     where

--- a/lol/Crypto/Lol/Types/IrreducibleChar2.hs
+++ b/lol/Crypto/Lol/Types/IrreducibleChar2.hs
@@ -33,7 +33,7 @@ import Data.Maybe (fromMaybe)
 
 instance (CharOf a ~ Prime2, Field a) => IrreduciblePoly a where
   -- https://ghc.haskell.org/trac/ghc/wiki/Migration/8.2#KindgeneralizationandMonoLocalBinds
-  irreduciblePoly :: forall (d :: k) . (Reflects d Int) => Tagged d (Polynomial a)
+  irreduciblePoly :: forall k (d :: k) . (Reflects d Int) => Tagged d (Polynomial a)
   irreduciblePoly = do
     let n = value @d
     return $ flip fromMaybe (lookup n polyMap) $ error $

--- a/lol/lol.cabal
+++ b/lol/lol.cabal
@@ -1,0 +1,156 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           lol
+version:        0.7.0.1
+synopsis:       A library for lattice cryptography.
+description:    Λ ⚬ λ (Lol) is a general-purpose library for ring-based lattice cryptography.  For a detailed description of interfaces and functionality, see <https://eprint.iacr.org/2015/1134 Λ ⚬ λ: Functional Lattice Cryptography>. The main backend for the library is <https://hackage.haskell.org/package/lol-cpp lol-cpp> (<https://hackage.haskell.org/package/lol-repa lol-repa> is currently out of date). For example cryptographic applications, see <https://hackage.haskell.org/package/lol-apps lol-apps>.
+category:       Crypto
+stability:      experimental
+homepage:       https://github.com/cpeikert/lol#readme
+bug-reports:    https://github.com/cpeikert/lol/issues
+author:         Eric Crockett <ecrockett0@gmail.com>,
+                Chris Peikert <cpeikert@alum.mit.edu>
+maintainer:     Eric Crockett <ecrockett@gmail.com>,
+                Chad Sharp <cmlsharp@umich.edu>
+copyright:      Eric Crockett,
+                Chris Peikert
+license:        GPL-3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README
+    CHANGES.md
+    Lol.proto
+    RLWE.proto
+
+source-repository head
+  type: git
+  location: https://github.com/cpeikert/lol
+
+flag llvm
+  description: Compile via LLVM. This produces much better object code, but you need to have the LLVM compiler installed.
+  manual: False
+  default: False
+
+flag opt
+  description: Turn on library optimizations
+  manual: False
+  default: True
+
+library
+  exposed-modules:
+      Crypto.Lol
+      Crypto.Lol.Types
+      Crypto.Lol.Factored
+      Crypto.Lol.Reflects
+      Crypto.Lol.CRTrans
+      Crypto.Lol.Gadget
+      Crypto.Lol.Prelude
+      Crypto.Lol.Cyclotomic.Cyc
+      Crypto.Lol.Cyclotomic.CycRep
+      Crypto.Lol.Cyclotomic.Language
+      Crypto.Lol.Cyclotomic.Linear
+      Crypto.Lol.RLWE.Continuous
+      Crypto.Lol.RLWE.Discrete
+      Crypto.Lol.RLWE.RLWR
+      Crypto.Lol.Cyclotomic.Tensor
+      Crypto.Lol.GaussRandom
+      Crypto.Lol.Types.Unsafe.Complex
+      Crypto.Lol.Types.FiniteField
+      Crypto.Lol.Types.IrreducibleChar2
+      Crypto.Lol.Types.IFunctor
+      Crypto.Lol.Types.IZipVector
+      Crypto.Lol.Types.Proto
+      Crypto.Lol.Types.Random
+      Crypto.Lol.Types.Unsafe.RRq
+      Crypto.Lol.Types.ZmStar
+      Crypto.Lol.Types.Unsafe.ZqBasic
+      Crypto.Proto.Lol
+      Crypto.Proto.Lol.LinearRq
+      Crypto.Proto.Lol.R
+      Crypto.Proto.Lol.Rq
+      Crypto.Proto.Lol.RqProduct
+      Crypto.Proto.Lol.K
+      Crypto.Proto.Lol.Kq
+      Crypto.Proto.Lol.KqProduct
+      Crypto.Proto.Lol.TypeRep
+      Crypto.Proto.RLWE
+      Crypto.Proto.RLWE.SampleContProduct
+      Crypto.Proto.RLWE.SampleDiscProduct
+      Crypto.Proto.RLWE.SampleRLWRProduct
+      Crypto.Proto.RLWE.SampleCont
+      Crypto.Proto.RLWE.SampleDisc
+      Crypto.Proto.RLWE.SampleRLWR
+      Crypto.Lol.Utils.ShowType
+      Crypto.Lol.Tests
+      Crypto.Lol.Benchmarks
+  other-modules:
+      Crypto.Lol.Cyclotomic.CRTSentinel
+      Crypto.Lol.FactoredDefs
+      Crypto.Lol.Types.Numeric
+      Crypto.Lol.PosBin
+      Crypto.Lol.PosBinDefs
+      Crypto.Lol.Utils.Tests
+      Crypto.Lol.Utils.Benchmarks
+      Crypto.Lol.Utils.PrettyPrint
+      Crypto.Lol.Utils.PrettyPrint.Diagnostic
+      Crypto.Lol.Utils.PrettyPrint.Table
+      Crypto.Lol.Tests.CycTests
+      Crypto.Lol.Tests.Default
+      Crypto.Lol.Tests.TensorTests
+      Crypto.Lol.Tests.ZqTests
+      Crypto.Lol.Benchmarks.CycBenches
+      Crypto.Lol.Benchmarks.Default
+      Crypto.Lol.Benchmarks.TensorBenches
+      Crypto.Lol.Benchmarks.CycRepBenches
+  build-depends:
+      MonadRandom >=0.5.1 && <0.6
+    , QuickCheck >=2.13.2 && <2.15
+    , ansi-terminal ==0.10.*
+    , arithmoi >=0.11.0 && <0.12
+    , base ==4.14.*
+    , bytestring >=0.10.8 && <0.12
+    , constraints >=0.10.1 && <0.14
+    , containers >=0.6.0 && <0.7
+    , criterion >=1.5.6 && <1.6
+    , criterion-measurement >=0.1.2 && <0.2
+    , crypto-api >=0.13.3 && <0.14
+    , data-default >=0.7.1 && <0.8
+    , deepseq >=1.4.4 && <1.5
+    , directory >=1.3.3 && <1.4
+    , monadcryptorandom >=0.7.2 && <0.8
+    , mtl >=2.2.2 && <2.3
+    , numeric-prelude >=0.4.3 && <0.5
+    , protocol-buffers >=2.4.12 && <2.5
+    , protocol-buffers-descriptor >=2.4.12 && <2.5
+    , random >=1.1 && <1.3
+    , reflection >=2.1.5 && <2.2
+    , singletons ==2.7.*
+    , statistics >=0.15.1 && <0.16
+    , tagged-transformer >=0.8.1 && <0.9
+    , template-haskell >=2.16.0 && <2.17
+    , test-framework >=0.8.2 && <0.9
+    , test-framework-quickcheck2 >=0.3.0 && <0.4
+    , vector >=0.12.0 && <0.13
+    , vector-th-unbox >=0.2.1 && <0.3
+  if flag(llvm)
+    ghc-options: -fllvm -optlo-O3 -pgmlo opt
+  default-language: Haskell2010
+
+test-suite test-lol
+  type: exitcode-stdio-1.0
+  main-is: LolTestsMain.hs
+  other-modules:
+      Paths_lol
+  hs-source-dirs:
+      tests
+  ghc-options: -main-is LolTestsMain
+  build-depends:
+      base
+    , lol
+    , test-framework
+  default-language: Haskell2010

--- a/lol/package.yaml
+++ b/lol/package.yaml
@@ -1,7 +1,7 @@
 _common: !include "./common.yaml"
 
 name: lol
-version: 0.7.0.0
+version: 0.7.0.1
 synopsis: A library for lattice cryptography.
 extra-source-files:
   - README
@@ -24,22 +24,22 @@ flags:
   <<: *commonFlags
 
 library:
-  when: 
+  when:
     <<: *commonLLVMFlag
-  dependencies: 
+  dependencies:
     - MonadRandom >= 0.5.1 && < 0.6
-    - base >= 4.12.0 && < 4.13
+    - base >= 4.14 && < 4.15
     - mtl >= 2.2.2 && < 2.3
-    - random >= 1.1 && < 1.2
+    - random >= 1.1 && < 1.3
     - deepseq >= 1.4.4 && < 1.5
-    - QuickCheck >= 2.13.2 && < 2.14
+    - QuickCheck >= 2.13.2 && < 2.15
     - containers >= 0.6.0 && < 0.7
-    - template-haskell >= 2.14.0 && < 2.15
-    - ansi-terminal >= 0.9.1 && < 0.10.0
-    - arithmoi >= 0.9.0 && < 0.10
-    - bytestring >= 0.10.8 && < 0.11
+    - template-haskell >= 2.16.0 && < 2.17
+    - ansi-terminal >= 0.10 && < 0.11
+    - arithmoi >= 0.11.0 && < 0.12
+    - bytestring >= 0.10.8 && < 0.12
     - vector >= 0.12.0 && < 0.13
-    - constraints >= 0.10.1 && < 0.11.0
+    - constraints >= 0.10.1 && < 0.14
     - criterion >= 1.5.6 && < 1.6
     - directory >= 1.3.3 && < 1.4
     - criterion-measurement >= 0.1.2 && < 0.2
@@ -52,11 +52,11 @@ library:
     - protocol-buffers >= 2.4.12 && < 2.5
     - protocol-buffers-descriptor >= 2.4.12 && < 2.5
     - reflection >= 2.1.5 && < 2.2
-    - singletons >= 2.5.1 && < 2.6
+    - singletons >= 2.7 && < 2.8
     - tagged-transformer >= 0.8.1 && < 0.9
     - test-framework >= 0.8.2 && < 0.9
     - test-framework-quickcheck2 >= 0.3.0 && < 0.4
-  
+
   exposed-modules:
     - Crypto.Lol
     - Crypto.Lol.Types

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,7 +16,7 @@
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
 
-resolver: lts-14.20
+resolver: lts-17.5
 compiler-check: newer-minor
 
 # User packages to be built.
@@ -49,9 +49,14 @@ packages:
 extra-deps:
 - monadcryptorandom-0.7.2.1
 - DRBG-0.5.5
+- cipher-aes128-0.7.0.5
 
 ghc-options:
     "$locals": -O1 -fexpose-all-unfoldings -fwarn-dodgy-imports
+
+flags:
+    cryptonite:
+        use_target_attributes: false
 
 # Override default flag values for local packages and extra-deps
 


### PR DESCRIPTION
In an effort to get this building again in [nixpkgs](https://github.com/NixOS/nixpkgs), I've updated all dependencies to include recent versions and made what I think are the appropriate migrations.

I've also bumped the versions to lol-0.7.0.1, lol-cpp-0.2.0.1, and lol-apps-0.3.0.1 as the changes shouldn't actually have any effect on the typing on the fronted.

The update of singletons to 2.7 requires ghc 8.10, hence the update to lst-17.5.